### PR TITLE
Axum Compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -764,9 +764,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
@@ -1730,9 +1730,9 @@ checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +931,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
+ "axum",
  "base64",
  "bounded-integer",
  "clap",
@@ -968,6 +1024,26 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1242,6 +1318,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1454,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
@@ -1497,6 +1589,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -291,6 +297,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-common"
@@ -573,6 +588,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -932,10 +972,11 @@ dependencies = [
  "async-trait",
  "atty",
  "axum",
- "base64",
+ "base64 0.21.0",
  "bounded-integer",
  "clap",
  "derive_more",
+ "headers",
  "heck",
  "http",
  "http-api-problem",
@@ -1152,7 +1193,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1345,7 +1386,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "chrono",
  "hex",
  "indexmap",
@@ -1378,6 +1419,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ base64 = { version = "0.21.0", optional = true }
 bounded-integer = { version = "0.5.6", features = ["std", "types", "serde1", "num-traits02"], optional = true }
 clap = { version = "4.2.7", features = ["derive"], optional = true }
 derive_more = "0.99.17"
+headers = { version = "0.3.8", optional = true }
 heck = "0.4.1"
 http = "0.2.9"
 http-api-problem = { version = "0.57.0", optional = true }
@@ -45,7 +46,7 @@ termcolor = "1.2.0"
 [features]
 default = []
 api-problem = ["http-api-problem"]
-axum-support = ["axum"]
+axum-support = ["axum", "headers"]
 cli = ["clap", "serde_yaml"]
 bytes = ["base64", "serde_with"]
 integer-restrictions = ["bounded-integer"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 [dependencies]
 anyhow = { version = "1.0.71" }
 async-trait = "0.1.68"
+axum = { version = "0.6.20", optional = true }
 base64 = { version = "0.21.0", optional = true }
 bounded-integer = { version = "0.5.6", features = ["std", "types", "serde1", "num-traits02"], optional = true }
 clap = { version = "4.2.7", features = ["derive"], optional = true }
@@ -44,6 +45,7 @@ termcolor = "1.2.0"
 [features]
 default = []
 api-problem = ["http-api-problem"]
+axum-support = ["axum"]
 cli = ["clap", "serde_yaml"]
 bytes = ["base64", "serde_with"]
 integer-restrictions = ["bounded-integer"]

--- a/scripts/compile_test_cases.sh
+++ b/scripts/compile_test_cases.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Compile all test cases.
+#
+# This only compiles the expected value, but that should be sufficient to validate that the generated code is plausible.
+
+set -euo pipefail
+
+# execute from the repo root, no matter where the script was invoked from
+cd "$(dirname "$0")"
+cd "$(git rev-parse --show-toplevel)"
+
+repo_path="$(realpath "$PWD")"
+
+tmpdir="$(mktemp -d --tmpdir "compile-tests.XXXXXX")"
+cd "$tmpdir"
+cargo init --name "compile-tests" --lib >/dev/null 2>&1
+cargo add openapi-gen --path "$repo_path" --features api-problem,axum-support,bytes,integer-restrictions,string-pattern,uuid >/dev/null 2>&1
+
+exit_code=0
+
+for case in "$repo_path"/tests/cases/*/expect.rs; do
+    file="$(realpath "$case")"
+    case_name="$(basename "$(dirname "$file")")"
+    echo "$case_name..."
+    cp "$file" src/lib.rs
+    if cargo check --quiet --lib; then
+      echo "  OK!"
+    else
+        exit_code=1
+    fi
+done
+
+cd "$repo_path"
+rm -rf "$tmpdir"
+
+exit $exit_code

--- a/scripts/regenerate_test_cases.sh
+++ b/scripts/regenerate_test_cases.sh
@@ -15,3 +15,5 @@ for definition in tests/cases/*/definition.yaml; do
     case_dir="$(dirname "$definition")"
     target/release/openapi-gen --no-emit-docs "$definition" > "$case_dir/expect.rs"
 done
+
+./scripts/compile_test_cases.sh

--- a/src/as_status_code.rs
+++ b/src/as_status_code.rs
@@ -1,0 +1,16 @@
+use http::StatusCode;
+
+/// This trait should be implemented for types which carry their status code internally.
+///
+/// This permits them to be used in a context where the appropriate context is not obvious,
+/// such as the `default` return value for an endpoint.
+pub trait AsStatusCode {
+    fn as_status_code(&self) -> StatusCode;
+}
+
+#[cfg(feature = "http-api-problem")]
+impl AsStatusCode for http_api_problem::HttpApiProblem {
+    fn as_status_code(&self) -> StatusCode {
+        self.status.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+    }
+}

--- a/src/axum_compat.rs
+++ b/src/axum_compat.rs
@@ -2,9 +2,18 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use heck::{ToShoutySnakeCase, ToSnakeCase};
+use proc_macro2::TokenStream;
+use quote::quote;
 use serde::Serialize;
 
-use crate::AsStatusCode;
+use crate::{
+    codegen::{
+        endpoint::verb::Verb, make_ident, value::object::BODY_IDENT, Object, Reference,
+        UnknownReference, Value,
+    },
+    ApiModel, AsStatusCode,
+};
 
 /// Construct a [`Response`][axum::response::Response] from the the default response type for an endpoint.
 #[inline]
@@ -14,4 +23,160 @@ where
 {
     let status = default.as_status_code();
     (status, Json(default)).into_response()
+}
+
+/// `value` must evaluate to an `&str`
+#[macro_export]
+macro_rules! header_value_of {
+    ($value:expr) => {
+        match openapi_gen::reexport::http::HeaderValue::from_str($value) {
+            Ok(value) => value,
+            Err(_err) => return (
+                openapi_gen::reexport::http::status::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("invalid header value for `{}` ({}:{}): all characters must be visible single-byte ascii (32-127)", stringify!($value), line!(), column!()),
+            ).into_response(),
+        }
+    };
+}
+
+// impl IntoResponse for CreateNaturalPersonIdentificationResponse {
+//     fn into_response(self) -> axum::response::Response {
+//         match self {
+//             CreateNaturalPersonIdentificationResponse::Created(created) => {
+//                 let CreateNaturalPersonIdentificationResponseCreated { location, body } = created;
+//                 let mut header_map = HeaderMap::with_capacity(1);
+//                 let location = header_value_of!(&location);
+//                 header_map.insert(LOCATION, location);
+//                 (StatusCode::CREATED, header_map, Json(body)).into_response()
+//             }
+//             CreateNaturalPersonIdentificationResponse::Default(default) => {
+//                 default_response(default)
+//             }
+//         }
+//     }
+// }
+
+/// Implement `IntoResponse` for a response type.
+///
+/// This implementation handles extracting response headers and appropriate status codes from the response enum, which in turn
+/// means that the response enum becomes a valid return value for a handler. This substantially simplifies handler generation.
+pub(crate) fn impl_into_response(
+    model: &ApiModel,
+    response: &Reference,
+    response_name: &str,
+    variant_name: &str,
+) -> Result<TokenStream, Error> {
+    let item = model
+        .resolve(*response)
+        .ok_or_else(|| UnknownReference(format!("response reference: {response:?}")))
+        .map_err(Error::context("getting response item"))?;
+
+    let response_ident = make_ident(response_name);
+    let variant_ident = make_ident(variant_name);
+    let variant_binding = {
+        let binding = variant_name.to_snake_case();
+        make_ident(&binding)
+    };
+    let item_ident = make_ident(&item.rust_name);
+    let status_ident = {
+        let binding = variant_name.to_shouty_snake_case();
+        make_ident(&binding)
+    };
+
+    // if the item is a default item, then we delegate to the `default_response` handler and trust that the
+    // user has properly implemented the necessary traits
+    if variant_name == "Default" {
+        return Ok(quote! {
+            #response_ident::#variant_ident(#variant_binding) => {
+                openapi_gen::axum_compat::default_response(#variant_binding)
+            }
+        });
+    }
+
+    let mut headers = Vec::new();
+
+    if let Some(content_type) = item.content_type.as_ref() {
+        let key = quote!(openapi_gen::reexport::http::header::CONTENT_TYPE);
+        let value = quote!(openapi_gen::reexport::http::HeaderValue::from_static(#content_type));
+        headers.push((key, value));
+    }
+
+    if let Value::Object(Object {
+        is_generated_body_and_headers: true,
+        members,
+    }) = &item.value
+    {
+        // unpack the object
+        let member_idents = members.keys().map(|member| make_ident(member));
+        let unpack_object = quote! {
+            let #item_ident = { #( #member_idents ),* } = #variant_binding;
+        };
+
+        // transform headers
+        for header_name in members.keys() {
+            if header_name == BODY_IDENT {
+                continue;
+            }
+
+            let header_ident = make_ident(header_name);
+
+            let lower_name = header_name.to_lowercase();
+            let key =
+                quote!(openapi_gen::reexport::http::header::HeaderName::from_static(#lower_name));
+
+            // TODO: invoke CanonicalForm::canonicalize here
+            let value = quote!(openapi_gen::header_value_of!(&#header_ident));
+
+            headers.push((key, value));
+        }
+
+        for (header_key_expr, header_value_expr) in headers {}
+        todo!()
+    }
+
+    let define_header_map = (!headers.is_empty()).then(|| {
+        let header_qty = headers.len();
+        let header_insert = headers.iter().map(|(key, value)| {
+            quote!{
+                header_map.insert(#key, #value);
+            }
+        });
+        quote!{
+            let mut header_map = openapi_gen::reexport::http::header::HeaderMap::with_capacity(#header_qty);
+            #( #header_insert )*
+        }
+    });
+    let header_map_ident_comma = (!headers.is_empty()).then_some(quote!(header_map,));
+
+    // todo: the rest of the owl
+    let _ = quote! {
+        (
+            openapi_gen::reexport::http::status::StatusCode::#status_ident,
+            #header_map_ident_comma
+            body,
+        ).into_response()
+    };
+
+    todo!()
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{context}")]
+pub struct Error {
+    context: String,
+    #[source]
+    inner: Box<dyn std::error::Error>,
+}
+
+impl Error {
+    fn context<'a, E>(context: &'a str) -> impl 'a + Fn(E) -> Self
+    where
+        E: 'static + std::error::Error,
+    {
+        |err| {
+            let context = context.into();
+            let inner = Box::new(err) as _;
+            Self { context, inner }
+        }
+    }
 }

--- a/src/axum_compat.rs
+++ b/src/axum_compat.rs
@@ -1,0 +1,17 @@
+use axum::{
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+
+use crate::AsStatusCode;
+
+/// Construct a [`Response`][axum::response::Response] from the the default response type for an endpoint.
+#[inline]
+pub fn default_response<D>(default: D) -> Response
+where
+    D: AsStatusCode + Serialize,
+{
+    let status = default.as_status_code();
+    (status, Json(default)).into_response()
+}

--- a/src/axum_compat/build_router.rs
+++ b/src/axum_compat/build_router.rs
@@ -13,7 +13,8 @@ use super::Error;
 
 /// Convert the variable identifier from curly brackets to leading colons
 ///
-/// ```
+/// ```ignore
+/// # // we ignore this test because this is a private function in a private module; the test runner does not have visibility
 /// # use openapi_gen::axum_compat::build_router::to_colon_path;
 /// assert_eq!(
 ///     to_colon_path("/users/{id}"),

--- a/src/axum_compat/build_router.rs
+++ b/src/axum_compat/build_router.rs
@@ -1,0 +1,155 @@
+use std::path::Path;
+
+use heck::ToSnakeCase;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::{
+    codegen::{endpoint::parameter::ParameterLocation, make_ident, Endpoint, UnknownReference},
+    ApiModel,
+};
+
+use super::Error;
+
+/// Convert the variable identifier from curly brackets to leading colons
+///
+/// ```
+/// # use openapi_gen::axum_compat::build_router::to_colon_path;
+/// assert_eq!(
+///     to_colon_path("/users/{id}"),
+///     "/users/:id",
+/// );
+/// ```
+fn to_colon_path(curly_bracket_path: &str) -> Result<String, Error> {
+    let mut out = String::with_capacity(curly_bracket_path.len());
+    let path = Path::new(curly_bracket_path);
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(_) => return Err(Error::new(format!("malformed path \"{curly_bracket_path}\": should be URL path not Windows"))),
+            std::path::Component::CurDir |
+            std::path::Component::ParentDir => return Err(Error::new(format!("malformed path \"{curly_bracket_path}\": current and parent components illegal"))),
+            std::path::Component::RootDir => {
+                // noop; the next component will handle this
+            },
+            std::path::Component::Normal(component) => {
+                // always unconditionally prefix with the path separator
+                out.push('/');
+
+                let component = component.to_str().ok_or_else(|| Error::new(format!("malformed path \"{curly_bracket_path}\": non-String characters present")))?;
+                if component.starts_with('{') && component.ends_with('}') {
+                    out.push(':');
+                    out.push_str(&component[1..component.len()-1]);
+                } else {
+                    out.push_str(component);
+                }
+            },
+        }
+    }
+
+    Ok(out)
+}
+
+fn build_route(model: &ApiModel, endpoint: &Endpoint) -> Result<TokenStream, Error> {
+    let path = to_colon_path(&endpoint.path)?;
+    let verb = endpoint.verb.emit_axum();
+    let prefix = quote!(openapi_gen::reexport::axum::extract);
+
+    let mut parameters = Vec::new();
+    let mut parameter_idents = Vec::new();
+
+    for (key, param) in endpoint.parameters.iter() {
+        let item = model
+            .resolve(param.item_ref)
+            .ok_or_else(|| UnknownReference(format!("{:?}", param.item_ref)))
+            .map_err(Error::context(format!(
+                "getting item for param \"{}\"",
+                key.name
+            )))?;
+
+        let type_ident = make_ident(&item.rust_name);
+        let variable_ident = make_ident(&item.rust_name.to_snake_case());
+
+        match key.location {
+            Some(ParameterLocation::Header) => parameters.push(quote! {
+                #prefix::TypedHeader(#variable_ident): #prefix::TypedHeader<#type_ident>
+            }),
+            Some(ParameterLocation::Path) => parameters.push(quote! {
+                #prefix::Path(#variable_ident): #prefix::Path<#type_ident>
+            }),
+            Some(ParameterLocation::Query) => parameters.push(quote! {
+                #prefix::Query(#variable_ident): #prefix::Query<#type_ident>
+            }),
+            Some(ParameterLocation::Cookie) => {
+                return Err(Error::new("cookie extractors not yet supported"))
+            }
+            None => {
+                return Err(Error::new(format!(
+                    "unknown parameter location for {}",
+                    item.rust_name
+                )))
+            }
+        }
+
+        parameter_idents.push(variable_ident);
+    }
+    if let Some(ref_) = endpoint.request_body {
+        // add body parameter last
+        let item = model
+            .resolve(ref_)
+            .ok_or_else(|| UnknownReference(format!("{ref_:?}")))
+            .map_err(Error::context("getting item for request body"))?;
+
+        let type_ident = make_ident(&item.rust_name);
+        let variable_ident = make_ident("request_body");
+
+        if item.is_json() {
+            parameters.push(quote! {
+                #prefix::Json(#variable_ident): #prefix::Json<#type_ident>
+            });
+        } else {
+            parameters.push(quote! {
+                #variable_ident: Vec<u8>
+            });
+        }
+
+        parameter_idents.push(variable_ident);
+    }
+
+    let method_name = make_ident(&endpoint.function_name(None));
+
+    Ok(quote! {
+        .route(
+            #path,
+            #verb({
+                let instance = instance.clone();
+                move |#( #parameters ),*| async move {
+                    instance.#method_name(#( #parameter_idents ),*).await
+                }
+            })
+        )
+    })
+}
+
+/// Create `fn build_router`, which transforms an arbitrary `Api` instance into a `Router`.
+pub(crate) fn fn_build_router(model: &ApiModel) -> Result<TokenStream, Error> {
+    let mut routes = Vec::<TokenStream>::new();
+
+    for endpoint in model.endpoints.iter() {
+        let route = build_route(model, endpoint)?;
+        routes.push(route);
+    }
+
+    Ok(quote! {
+        /// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+        pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+        where
+            Instance: 'static + Api + Send + Sync
+        {
+            // `instance` is unused if there are no endpoints
+            #[allow(unused_variables)]
+            let instance = ::std::sync::Arc::new(instance);
+            openapi_gen::reexport::axum::Router::new()
+            #( #routes )*
+        }
+    })
+}

--- a/src/axum_compat/header.rs
+++ b/src/axum_compat/header.rs
@@ -1,0 +1,52 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::{
+    axum_compat::Error,
+    codegen::{make_ident, Item},
+    ApiModel,
+};
+
+/// Implement `Header` for a header type.
+///
+/// This is somewhat fragile. It assumes that it is safe to defer through `CanonicalForm`, which implies that that implementation
+/// is infallible and produdes output containing only visible ASCII (32-127). We'll have to see if it causes problems in practice.
+pub(crate) fn impl_header(_model: &ApiModel, item: &Item) -> Result<TokenStream, Error> {
+    if item.is_typedef() {
+        return Err(Error::new(format!(
+            "item '{}' is a typdef, so cannot support a `Header` implementation",
+            &item.rust_name
+        )));
+    }
+
+    let item_name = make_ident(&item.rust_name);
+    let header_name = item.spec_name.to_lowercase();
+
+    Ok(quote! {
+        impl openapi_gen::reexport::headers::Header for #item_name {
+            fn name() -> &'static openapi_gen::reexport::headers::HeaderName {
+                static NAME: openapi_gen::reexport::headers::HeaderName = openapi_gen::reexport::headers::HeaderName::from_static(#header_name);
+                &NAME
+            }
+
+            fn decode<'i, I>(values: &mut I) -> Result<Self, openapi_gen::reexport::headers::Error>
+            where
+                Self: Sized,
+                I: Iterator<Item = &'i openapi_gen::reexport::headers::HeaderValue>,
+            {
+                let value = values.next().ok_or_else(openapi_gen::reexport::headers::Error::invalid)?;
+                let value_str = value.to_str().map_err(|_| openapi_gen::reexport::headers::Error::invalid())?;
+                openapi_gen::CanonicalForm::validate(value_str).map_err(|_| openapi_gen::reexport::headers::Error::invalid())
+            }
+
+            fn encode<E>(&self, values: &mut E)
+            where
+                E: ::std::iter::Extend<openapi_gen::reexport::headers::HeaderValue>
+            {
+                let value = openapi_gen::CanonicalForm::canonicalize(self).expect("header encoding must be infallible");
+                let header_value = openapi_gen::reexport::headers::HeaderValue::from_str(&value).expect("header canonical form must include only visible ascii");
+                values.extend(::std::iter::once(header_value));
+            }
+        }
+    })
+}

--- a/src/axum_compat/into_response.rs
+++ b/src/axum_compat/into_response.rs
@@ -158,12 +158,8 @@ fn impl_into_response_for_response_type(
 
     // wrap the body in a JSON wrapper if it is not a unit type, and
     // the item content-type ends with "json"
-    let wrap_with_json = !matches!(&item.value, Value::Scalar(crate::codegen::Scalar::Unit))
-        && item
-            .content_type
-            .as_deref()
-            .unwrap_or("json")
-            .eq_ignore_ascii_case("json");
+    let wrap_with_json =
+        !matches!(&item.value, Value::Scalar(crate::codegen::Scalar::Unit)) && item.is_json();
 
     let body = if wrap_with_json {
         quote!(openapi_gen::reexport::axum::Json(#body))

--- a/src/axum_compat/mod.rs
+++ b/src/axum_compat/mod.rs
@@ -1,0 +1,71 @@
+//! Axum compatibility boilerplate generator.
+//!
+//! There are three major components to axum compatibility:
+//!
+//! - `impl IntoResponse` for all response types
+//! - `impl Header` for all header types
+//! - `fn build_router` to convert the implementation into an appropriate router
+//!
+//! For simplicity, we provide a single function `axum_items` which generates everything required.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::{axum_compat::into_response::impl_into_response, ApiModel};
+
+mod into_response;
+
+pub use into_response::default_response;
+
+pub(crate) fn axum_items(model: &ApiModel) -> Result<TokenStream, Error> {
+    // TODO: implement header_impls
+    let header_impls = Vec::<TokenStream>::new();
+
+    let mut into_response_impls = Vec::with_capacity(model.endpoints.len());
+
+    for endpoint in model.endpoints.iter() {
+        let reference = endpoint.response;
+
+        into_response_impls.push(
+            impl_into_response(model, &reference)
+                .map_err(Error::context("implementing `IntoResponse`"))?,
+        );
+    }
+
+    // TODO: implement builder for fn build_router
+    let build_router = TokenStream::default();
+
+    Ok(quote! {
+        #( #header_impls )*
+        #( #into_response_impls )*
+        #build_router
+    })
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{msg}")]
+pub struct Error {
+    msg: String,
+    #[source]
+    inner: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+impl Error {
+    fn new(msg: impl Into<String>) -> Self {
+        let msg = msg.into();
+        let inner = None;
+        Self { msg, inner }
+    }
+
+    fn context<C, E>(context: C) -> impl FnOnce(E) -> Self
+    where
+        C: Into<String>,
+        Box<dyn 'static + std::error::Error + Send + Sync>: From<E>,
+    {
+        move |err| {
+            let msg = context.into();
+            let inner = Some(err.into());
+            Self { msg, inner }
+        }
+    }
+}

--- a/src/axum_compat/mod.rs
+++ b/src/axum_compat/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     ApiModel,
 };
 
+mod build_router;
 mod header;
 mod into_response;
 
@@ -41,8 +42,7 @@ pub(crate) fn axum_items(model: &ApiModel) -> Result<TokenStream, Error> {
         );
     }
 
-    // TODO: implement builder for fn build_router
-    let build_router = TokenStream::default();
+    let build_router = build_router::fn_build_router(model)?;
 
     Ok(quote! {
         #( #header_impls )*

--- a/src/canonical_form/impls/bounded_integer.rs
+++ b/src/canonical_form/impls/bounded_integer.rs
@@ -1,11 +1,14 @@
+use std::borrow::Borrow;
+
 use crate::{CanonicalForm, CanonicalizeError, ValidationError};
 use bounded_integer::{BoundedI32, BoundedI64};
 use serde_json::Number;
 
 impl<const MIN: i64, const MAX: i64> CanonicalForm for BoundedI64<MIN, MAX> {
+    type ParseableFrom = Number;
     type JsonRepresentation = Number;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &Number) -> Result<Self, ValidationError> {
         let v = i64::validate(from)?;
         BoundedI64::new(v)
             .ok_or_else(|| ValidationError::reason::<Self>(format!("{v} not in {MIN}..={MAX}")))
@@ -17,9 +20,10 @@ impl<const MIN: i64, const MAX: i64> CanonicalForm for BoundedI64<MIN, MAX> {
 }
 
 impl<const MIN: i32, const MAX: i32> CanonicalForm for BoundedI32<MIN, MAX> {
+    type ParseableFrom = Number;
     type JsonRepresentation = Number;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &Number) -> Result<Self, ValidationError> {
         let v = i32::validate(from)?;
         BoundedI32::new(v)
             .ok_or_else(|| ValidationError::reason::<Self>(format!("{v} not in {MIN}..={MAX}")))

--- a/src/canonical_form/impls/bounded_integer.rs
+++ b/src/canonical_form/impls/bounded_integer.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 use crate::{CanonicalForm, CanonicalizeError, ValidationError};
 use bounded_integer::{BoundedI32, BoundedI64};
 use serde_json::Number;

--- a/src/canonical_form/impls/mod.rs
+++ b/src/canonical_form/impls/mod.rs
@@ -8,8 +8,9 @@ use crate::{CanonicalForm, CanonicalizeError, Reason, ValidationError};
 macro_rules! canonical_form_transparent {
     ($t:ty) => {
         impl CanonicalForm for $t {
+            type ParseableFrom = $t;
             type JsonRepresentation = $t;
-            fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+            fn validate(from: &$t) -> Result<Self, ValidationError> {
                 Ok(from.to_owned())
             }
             fn canonicalize(&self) -> Result<$t, CanonicalizeError> {
@@ -25,8 +26,9 @@ canonical_form_transparent!(String);
 macro_rules! canonical_form_display_fromstr {
     ($t:path) => {
         impl CanonicalForm for $t {
+            type ParseableFrom = str;
             type JsonRepresentation = String;
-            fn validate(from: &String) -> Result<Self, ValidationError> {
+            fn validate(from: &str) -> Result<Self, ValidationError> {
                 from.parse()
                     .map_err(|err| ValidationError::reason::<Self>(Reason::from_err(err)))
             }

--- a/src/canonical_form/impls/numbers.rs
+++ b/src/canonical_form/impls/numbers.rs
@@ -3,9 +3,10 @@ use serde_json::Number;
 use crate::{CanonicalForm, CanonicalizeError, Reason, ValidationError};
 
 impl CanonicalForm for f64 {
+    type ParseableFrom = Number;
     type JsonRepresentation = Number;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &Self::ParseableFrom) -> Result<Self, ValidationError> {
         from.as_f64()
             .ok_or_else(|| ValidationError::reason::<Self>(format!("number not finite: {from}")))
     }
@@ -17,9 +18,10 @@ impl CanonicalForm for f64 {
 }
 
 impl CanonicalForm for f32 {
+    type ParseableFrom = Number;
     type JsonRepresentation = Number;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &Self::ParseableFrom) -> Result<Self, ValidationError> {
         f64::validate(from).map(|n| n as _)
     }
 
@@ -29,9 +31,10 @@ impl CanonicalForm for f32 {
 }
 
 impl CanonicalForm for i64 {
+    type ParseableFrom = Number;
     type JsonRepresentation = Number;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &Self::ParseableFrom) -> Result<Self, ValidationError> {
         from.as_i64()
             .ok_or_else(|| ValidationError::reason::<Self>(format!("number not integer: {from}")))
     }
@@ -42,9 +45,10 @@ impl CanonicalForm for i64 {
 }
 
 impl CanonicalForm for i32 {
+    type ParseableFrom = Number;
     type JsonRepresentation = Number;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &Self::ParseableFrom) -> Result<Self, ValidationError> {
         i64::validate(from).and_then(|n| {
             n.try_into()
                 .map_err(|err| ValidationError::reason::<Self>(Reason::from_err(err)))

--- a/src/canonical_form/impls/time.rs
+++ b/src/canonical_form/impls/time.rs
@@ -13,9 +13,10 @@ const DATE_FORM: &[FormatItem<'static>] = format_description!("[year]-[month]-[d
 ///
 /// [RFC 3339, section 5.6]: https://tools.ietf.org/html/rfc3339#section-5.6
 impl CanonicalForm for Date {
+    type ParseableFrom = str;
     type JsonRepresentation = String;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &str) -> Result<Self, ValidationError> {
         Self::parse(from, &DATE_FORM)
             .map_err(|err| ValidationError::reason::<Self>(Reason::from_err(err)))
     }
@@ -33,9 +34,10 @@ impl CanonicalForm for Date {
 ///
 /// [RFC 3339, section 5.6]: https://tools.ietf.org/html/rfc3339#section-5.6
 impl CanonicalForm for OffsetDateTime {
+    type ParseableFrom = str;
     type JsonRepresentation = String;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &str) -> Result<Self, ValidationError> {
         Self::parse(from, &Rfc3339)
             .map_err(|err| ValidationError::reason::<Self>(Reason::from_err(err)))
     }

--- a/src/canonical_form/mod.rs
+++ b/src/canonical_form/mod.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 pub(crate) mod impls;
 
 #[derive(Debug, thiserror::Error, derive_more::From)]

--- a/src/canonical_form/mod.rs
+++ b/src/canonical_form/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 pub(crate) mod impls;
 
 #[derive(Debug, thiserror::Error, derive_more::From)]
@@ -77,8 +79,15 @@ impl CanonicalizeError {
 /// For simplicity, this is a copying operation; this trait copies all the data
 /// passed through it, instead of taking ownership.
 pub trait CanonicalForm: Sized {
+    /// The simplest parseable type from which this can be validated.
+    ///
+    /// This must be borrowable from `Self::JsonRepresentation`.
+    type ParseableFrom: ?Sized;
+
     /// What type this is expressed as in JSON.
-    type JsonRepresentation: std::fmt::Display;
+    ///
+    /// When borrowed,
+    type JsonRepresentation: std::fmt::Display + std::borrow::Borrow<Self::ParseableFrom>;
 
     /// Ensure that all constraints on this type are upheld.
     ///
@@ -94,7 +103,7 @@ pub trait CanonicalForm: Sized {
     /// which should be called from within this function.
     ///
     /// The input can be anything which, when borrowed, is the same as the JSON representation.
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError>;
+    fn validate(from: &Self::ParseableFrom) -> Result<Self, ValidationError>;
 
     /// Emit the canonical form as a JSON-compatible item.
     ///
@@ -122,10 +131,10 @@ pub trait CanonicalForm: Sized {
 macro_rules! newtype_derive_canonical_form {
     ($outer:path, $inner:path) => {
         impl $crate::CanonicalForm for $outer {
+            type ParseableFrom = <$inner as $crate::CanonicalForm>::ParseableFrom;
             type JsonRepresentation = <$inner as $crate::CanonicalForm>::JsonRepresentation;
-            fn validate(
-                from: &<Self as $crate::CanonicalForm>::JsonRepresentation,
-            ) -> Result<Self, $crate::ValidationError> {
+
+            fn validate(from: &Self::ParseableFrom) -> Result<Self, $crate::ValidationError> {
                 let inner = <$inner>::validate(from)?;
                 Ok(Self(inner))
             }

--- a/src/codegen/api_model.rs
+++ b/src/codegen/api_model.rs
@@ -251,6 +251,18 @@ impl<R> ApiModel<R> {
         }
         Ok(())
     }
+
+    /// Iterate references over all currently-known items.
+    //
+    // This function is not currently called from all feature sets, so it might erroneously trigger
+    // a dead code warning without this annotation.
+    #[allow(dead_code)]
+    pub(crate) fn iter_items(&self) -> impl '_ + Iterator<Item = R>
+    where
+        R: AsBackref,
+    {
+        (0..self.items.len()).map(R::from_backref)
+    }
 }
 
 // These functions only appear when we use potentially forward references.
@@ -293,6 +305,9 @@ impl ApiModel<Ref> {
     /// All inline item definitions are added in topographic order.
     ///
     /// External item definitions are permitted to be forward references.
+    //
+    // Unfortunatley I think we're stuck with this argument count.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_inline_items(
         &mut self,
         spec: &OpenAPI,

--- a/src/codegen/api_model.rs
+++ b/src/codegen/api_model.rs
@@ -276,6 +276,7 @@ impl ApiModel<Ref> {
                 reference_name,
                 schema,
                 containing_object,
+                None,
             ),
             ReferenceOr::Reference { reference } => match self.named_references.get(reference) {
                 Some(position) => Ok(Ref::Back(*position)),
@@ -297,8 +298,17 @@ impl ApiModel<Ref> {
         reference_name: Option<&str>,
         schema: &Schema,
         containing_object: ContainingObject,
+        content_type: Option<String>,
     ) -> Result<Ref, Error> {
-        let item = Item::parse_schema(spec, self, spec_name, rust_name, schema, containing_object)?;
+        let item = Item::parse_schema(
+            spec,
+            self,
+            spec_name,
+            rust_name,
+            schema,
+            containing_object,
+            content_type,
+        )?;
         self.add_item(item, reference_name)
     }
 
@@ -580,6 +590,7 @@ impl ApiModel {
                     &rust_name,
                     reference_name,
                     schema,
+                    None,
                     None,
                 )?,
                 OrScalar::Scalar(scalar) => {

--- a/src/codegen/endpoint/header.rs
+++ b/src/codegen/endpoint/header.rs
@@ -78,6 +78,11 @@ pub(crate) fn create_header(
         }
     };
 
+    // simpler to edit the newly-created item than to add this param to all code paths for creating an item
+    if let Some(item) = model.resolve_mut(&ref_) {
+        item.impl_header = true;
+    }
+
     if let Some(named_reference) = reference_name {
         model
             .insert_named_reference_for(named_reference, &ref_)

--- a/src/codegen/endpoint/header.rs
+++ b/src/codegen/endpoint/header.rs
@@ -65,7 +65,15 @@ pub(crate) fn create_header(
         Some(ReferenceOr::Item(schema)) => {
             // if we defined an inline schema, we need to add the item
             model
-                .add_inline_items(spec, spec_name, &rust_name, reference_name, schema, None)
+                .add_inline_items(
+                    spec,
+                    spec_name,
+                    &rust_name,
+                    reference_name,
+                    schema,
+                    None,
+                    None,
+                )
                 .map_err(model_err("adding parameter item"))?
         }
     };

--- a/src/codegen/endpoint/mod.rs
+++ b/src/codegen/endpoint/mod.rs
@@ -88,7 +88,7 @@ impl<R> Endpoint<R> {
     /// The endpoint doesn't know internally whether it is unique at the verb/path combo,
     /// or whether it needs a suffix to disambiguate from other content types. That must
     /// therefore be provided externally.
-    fn function_name(&self, suffix: Option<&str>) -> String {
+    pub(crate) fn function_name(&self, suffix: Option<&str>) -> String {
         self.operation_id
             .clone()
             .unwrap_or_else(|| {

--- a/src/codegen/endpoint/parameter.rs
+++ b/src/codegen/endpoint/parameter.rs
@@ -109,7 +109,15 @@ pub(crate) fn insert_parameter(
         ReferenceOr::Item(schema) => {
             // if we defined an inline schema, we need to add the item
             model
-                .add_inline_items(spec, &spec_name, &rust_name, reference_name, schema, None)
+                .add_inline_items(
+                    spec,
+                    &spec_name,
+                    &rust_name,
+                    reference_name,
+                    schema,
+                    None,
+                    None,
+                )
                 .context("adding parameter item")?
         }
     };

--- a/src/codegen/endpoint/request_body.rs
+++ b/src/codegen/endpoint/request_body.rs
@@ -62,7 +62,8 @@ pub(crate) fn convert_optional_schema_ref(
             })
         }
         Some(ReferenceOr::Item(schema)) => {
-            Item::parse_schema(spec, model, &spec_name, &rust_name, schema, None).map_err(wrap_err)
+            Item::parse_schema(spec, model, &spec_name, &rust_name, schema, None, None)
+                .map_err(wrap_err)
         }
     }
 }

--- a/src/codegen/endpoint/request_body.rs
+++ b/src/codegen/endpoint/request_body.rs
@@ -134,10 +134,7 @@ pub(crate) fn create_request_body(
                 )?;
                 variant_item.nullable = !request_body.required;
                 let definition = model.add_item(variant_item, None).map_err(wrap_err)?;
-                Ok(one_of_enum::Variant {
-                    definition,
-                    mapping_name: None,
-                })
+                Ok(one_of_enum::Variant::new(definition, None))
             })
             .collect::<Result<_, _>>()?;
         let value = one_of_enum::OneOfEnum {

--- a/src/codegen/endpoint/response.rs
+++ b/src/codegen/endpoint/response.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use heck::{AsUpperCamelCase, ToUpperCamelCase};
+use heck::{AsUpperCamelCase, ToSnakeCase, ToUpperCamelCase};
 use openapiv3::{Header, OpenAPI, ReferenceOr, Response, Responses, Schema, StatusCode};
 
 use crate::{
@@ -148,9 +148,12 @@ fn make_response_object_with_headers_and_body<'a>(
             }
         };
 
+        let mut field_name = header_name.to_snake_case();
+        model.deconflict_member_or_variant_ident(&mut field_name);
+
         object
             .members
-            .insert(header_name.to_owned(), ObjectMember::new(definition));
+            .insert(field_name, ObjectMember::new(definition));
     }
 
     if object.members.contains_key(BODY_IDENT) {

--- a/src/codegen/endpoint/response.rs
+++ b/src/codegen/endpoint/response.rs
@@ -302,10 +302,8 @@ pub(crate) fn create_responses(
         {
             let definition = definition.clone();
             let mapping_name = Some(spec_name.clone());
-            out.variants.push(one_of_enum::Variant {
-                definition,
-                mapping_name,
-            });
+            out.variants
+                .push(one_of_enum::Variant::new(definition, mapping_name));
         }
     }
 

--- a/src/codegen/endpoint/verb.rs
+++ b/src/codegen/endpoint/verb.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "axum-support")]
+use proc_macro2::TokenStream;
+
 /// A HTTP Verb
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, strum::Display, strum::EnumString)]
 #[strum(serialize_all = "UPPERCASE", ascii_case_insensitive)]
@@ -18,5 +21,17 @@ impl Verb {
             Verb::Get | Verb::Head | Verb::Delete | Verb::Trace => false,
             Verb::Put | Verb::Post | Verb::Options | Verb::Patch => true,
         }
+    }
+
+    #[cfg(feature = "axum-support")]
+    pub(crate) fn emit_axum(&self) -> TokenStream {
+        use quote::quote;
+
+        use crate::codegen::make_ident;
+
+        let method_name = self.to_string().to_lowercase();
+        let method_ident = make_ident(&method_name);
+
+        quote!(openapi_gen::reexport::axum::routing::#method_ident)
     }
 }

--- a/src/codegen/item.rs
+++ b/src/codegen/item.rs
@@ -315,7 +315,7 @@ impl Item {
         // cast to bytes in case it's not ascii, so we don't have an indexing panic
         let content_type = self.content_type.as_deref().unwrap_or("json").as_bytes();
         // re-subslice the string to get the trailing four bytes
-        let content_type = &content_type[content_type.len() - 4..];
+        let content_type = &content_type[content_type.len().checked_sub(4).unwrap_or_default()..];
         content_type.eq_ignore_ascii_case(b"json")
     }
 

--- a/src/codegen/item.rs
+++ b/src/codegen/item.rs
@@ -309,6 +309,16 @@ impl Item {
             }
     }
 
+    /// `true` when the item is probably json
+    #[allow(dead_code)]
+    pub(crate) fn is_json(&self) -> bool {
+        // cast to bytes in case it's not ascii, so we don't have an indexing panic
+        let content_type = self.content_type.as_deref().unwrap_or("json").as_bytes();
+        // re-subslice the string to get the trailing four bytes
+        let content_type = &content_type[content_type.len() - 4..];
+        content_type.eq_ignore_ascii_case(b"json")
+    }
+
     /// Is this item public?
     ///
     /// True if any:

--- a/src/codegen/item.rs
+++ b/src/codegen/item.rs
@@ -129,6 +129,14 @@ pub struct Item<Ref = Reference> {
     pub nullable: bool,
     /// What value this item contains
     pub value: Value<Ref>,
+    /// The `content-type` MIME type known to be associated with this item.
+    ///
+    /// Not all items have a known MIME type. The most common case where this is set are
+    /// direct `*Request` and `*Response` items.
+    ///
+    /// For items defined in `components/schemas` and defined inline within other item definitions,
+    /// this should be unset.
+    pub content_type: Option<String>,
 }
 
 impl<R> Default for Item<R> {
@@ -142,6 +150,7 @@ impl<R> Default for Item<R> {
             pub_typedef: Default::default(),
             nullable: Default::default(),
             value: Default::default(),
+            content_type: Default::default(),
         }
     }
 }
@@ -160,6 +169,7 @@ impl Item<Ref> {
             pub_typedef,
             nullable,
             value,
+            content_type,
         } = self;
         let value = value.resolve_refs(resolver)?;
         Ok(Item {
@@ -171,6 +181,7 @@ impl Item<Ref> {
             pub_typedef,
             nullable,
             value,
+            content_type,
         })
     }
 
@@ -185,6 +196,7 @@ impl Item<Ref> {
         rust_name: &str,
         schema: &Schema,
         containing_object: ContainingObject,
+        content_type: Option<String>,
     ) -> Result<Self, ParseItemError> {
         let value: Value<Ref> = match &schema.schema_kind {
             SchemaKind::Type(Type::Boolean {}) => Value::Scalar(Scalar::Bool),
@@ -269,6 +281,7 @@ impl Item<Ref> {
             pub_typedef,
             nullable,
             value,
+            content_type,
         })
     }
 }

--- a/src/codegen/value/one_of_enum.rs
+++ b/src/codegen/value/one_of_enum.rs
@@ -206,9 +206,9 @@ impl OneOfEnum {
             .enumerate()
             .map(|(idx, variant)| {
                 let variant_name = variant.compute_variant_name(idx, &name_resolver);
-                let ident = make_ident(&variant_name);
+                let ident = make_ident(variant_name);
                 let referent = make_ident(name_resolver(variant.definition)?);
-                let attributes = variant.serde_attributes(&variant_name);
+                let attributes = variant.serde_attributes(variant_name);
                 let attributes =
                     (!attributes.is_empty()).then(|| quote!(#[serde( #( #attributes)* )]));
                 Ok(quote! {

--- a/src/codegen/value/one_of_enum.rs
+++ b/src/codegen/value/one_of_enum.rs
@@ -37,6 +37,10 @@ impl<R> Variant<R> {
     /// when the name resolver is available. In general, code which requires access to the computed
     /// name of the variant should only run after its definition has been emitted.
     // TODO: can we improve on that, compute it earlier somehow?
+    //
+    // This function is not currently called from all feature sets, so it might erroneously trigger
+    // a dead code warning without this annotation.
+    #[allow(dead_code)]
     pub(crate) fn computed_name(&self) -> Option<&str> {
         self.computed_name.get().map(String::as_str)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@ pub use codegen::{ApiModel, Error};
 #[cfg(feature = "bytes")]
 pub use well_known_types::Bytes;
 
+#[cfg(feature = "axum-support")]
+pub mod axum_compat;
+
 /// Reexport crates used by generated code.
 ///
 /// This makes it much easier to keep the types in sync between the generated code and your own types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
+pub(crate) mod as_status_code;
 pub(crate) mod canonical_form;
 pub(crate) mod codegen;
 pub(crate) mod openapi_compat;
 pub(crate) mod resolve_trait;
 pub(crate) mod well_known_types;
+
+pub use as_status_code::AsStatusCode;
 
 pub use canonical_form::{
     CanonicalForm, CanonicalizeError, ConstraintViolation, Reason, ValidationError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub mod reexport {
     #[cfg(feature = "integer-restrictions")]
     pub use bounded_integer;
     pub use derive_more;
+    #[cfg(feature = "axum-support")]
+    pub use headers;
     pub use heck;
     pub use http;
     #[cfg(feature = "api-problem")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,13 @@ pub mod axum_compat;
 /// This makes it much easier to keep the types in sync between the generated code and your own types.
 pub mod reexport {
     pub use async_trait;
+    #[cfg(feature = "axum-support")]
+    pub use axum;
     #[cfg(feature = "integer-restrictions")]
     pub use bounded_integer;
     pub use derive_more;
     pub use heck;
+    pub use http;
     #[cfg(feature = "api-problem")]
     pub use http_api_problem;
     #[cfg(feature = "string-pattern")]

--- a/src/well_known_types/bytes.rs
+++ b/src/well_known_types/bytes.rs
@@ -21,9 +21,10 @@ use crate::{CanonicalForm, Reason, ValidationError};
 pub struct Bytes(pub Vec<u8>);
 
 impl CanonicalForm for Bytes {
+    type ParseableFrom = str;
     type JsonRepresentation = String;
 
-    fn validate(from: &Self::JsonRepresentation) -> Result<Self, ValidationError> {
+    fn validate(from: &str) -> Result<Self, ValidationError> {
         from.parse()
     }
 

--- a/tests/cases/18_response_value/definition.yaml
+++ b/tests/cases/18_response_value/definition.yaml
@@ -75,3 +75,5 @@ components:
       schema:
         type: string
         format: path
+        x-newtype:
+          pub: true

--- a/tests/cases/18_response_value/expect.rs
+++ b/tests/cases/18_response_value/expect.rs
@@ -12,6 +12,9 @@
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct IdentificationId(pub openapi_gen::reexport::uuid::Uuid);
+openapi_gen::newtype_derive_canonical_form!(
+    IdentificationId, openapi_gen::reexport::uuid::Uuid
+);
 #[derive(
     Debug,
     Clone,
@@ -25,6 +28,7 @@ pub struct IdentificationId(pub openapi_gen::reexport::uuid::Uuid);
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct PersonId(pub openapi_gen::reexport::uuid::Uuid);
+openapi_gen::newtype_derive_canonical_form!(PersonId, openapi_gen::reexport::uuid::Uuid);
 type AdditionalInformationItem = String;
 pub type AdditionalInformation = Vec<AdditionalInformationItem>;
 type Id = IdentificationId;
@@ -46,7 +50,19 @@ pub struct NaturalPersonIdentification {
     pub person_id: PersonId,
 }
 type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
-pub type Location = String;
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    openapi_gen::reexport::serde::Serialize,
+    openapi_gen::reexport::serde::Deserialize,
+    Eq,
+    Hash,
+    openapi_gen::reexport::derive_more::Constructor
+)]
+#[serde(crate = "openapi_gen::reexport::serde")]
+pub struct Location(pub String);
+openapi_gen::newtype_derive_canonical_form!(Location, String);
 pub type CreateNaturalPersonIdentificationRequest = NaturalPersonIdentification;
 #[derive(
     Debug,
@@ -87,6 +103,40 @@ Operation ID: `createNaturalPersonIdentification`
         &self,
         request_body: CreateNaturalPersonIdentificationRequest,
     ) -> CreateNaturalPersonIdentificationResponse;
+}
+impl openapi_gen::reexport::headers::Header for Location {
+    fn name() -> &'static openapi_gen::reexport::headers::HeaderName {
+        static NAME: openapi_gen::reexport::headers::HeaderName = openapi_gen::reexport::headers::HeaderName::from_static(
+            "location",
+        );
+        &NAME
+    }
+    fn decode<'i, I>(
+        values: &mut I,
+    ) -> Result<Self, openapi_gen::reexport::headers::Error>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i openapi_gen::reexport::headers::HeaderValue>,
+    {
+        let value = values
+            .next()
+            .ok_or_else(openapi_gen::reexport::headers::Error::invalid)?;
+        let value_str = value
+            .to_str()
+            .map_err(|_| openapi_gen::reexport::headers::Error::invalid())?;
+        openapi_gen::CanonicalForm::validate(value_str)
+            .map_err(|_| openapi_gen::reexport::headers::Error::invalid())
+    }
+    fn encode<E>(&self, values: &mut E)
+    where
+        E: ::std::iter::Extend<openapi_gen::reexport::headers::HeaderValue>,
+    {
+        let value = openapi_gen::CanonicalForm::canonicalize(self)
+            .expect("header encoding must be infallible");
+        let header_value = openapi_gen::reexport::headers::HeaderValue::from_str(&value)
+            .expect("header canonical form must include only visible ascii");
+        values.extend(::std::iter::once(header_value));
+    }
 }
 impl openapi_gen::reexport::axum::response::IntoResponse
 for CreateNaturalPersonIdentificationResponse {

--- a/tests/cases/18_response_value/expect.rs
+++ b/tests/cases/18_response_value/expect.rs
@@ -170,4 +170,28 @@ for CreateNaturalPersonIdentificationResponse {
         }
     }
 }
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+        .route(
+            "/natural-persons",
+            openapi_gen::reexport::axum::routing::post({
+                let instance = instance.clone();
+                move |
+                    openapi_gen::reexport::axum::extract::Json(
+                        request_body,
+                    ): openapi_gen::reexport::axum::extract::Json<
+                        CreateNaturalPersonIdentificationRequest,
+                    >|
+                async move {
+                    instance.create_natural_person_identification(request_body).await
+                }
+            }),
+        )
+}
 

--- a/tests/cases/18_response_value/expect.rs
+++ b/tests/cases/18_response_value/expect.rs
@@ -60,7 +60,6 @@ pub type CreateNaturalPersonIdentificationRequest = NaturalPersonIdentification;
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct CreateNaturalPersonIdentificationResponseCreated {
-    #[serde(rename = "Location")]
     pub location: Location,
     pub body: NaturalPersonIdentification,
 }
@@ -88,5 +87,37 @@ Operation ID: `createNaturalPersonIdentification`
         &self,
         request_body: CreateNaturalPersonIdentificationRequest,
     ) -> CreateNaturalPersonIdentificationResponse;
+}
+impl openapi_gen::reexport::axum::response::IntoResponse
+for CreateNaturalPersonIdentificationResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            CreateNaturalPersonIdentificationResponse::Created(created) => {
+                let CreateNaturalPersonIdentificationResponseCreated {
+                    location,
+                    body,
+                } = created;
+                let mut header_map = openapi_gen::reexport::http::header::HeaderMap::with_capacity(
+                    1usize,
+                );
+                header_map
+                    .insert(
+                        openapi_gen::reexport::http::header::HeaderName::from_static(
+                            "location",
+                        ),
+                        openapi_gen::header_value_of!(& location),
+                    );
+                (
+                    openapi_gen::reexport::http::status::StatusCode::CREATED,
+                    header_map,
+                    openapi_gen::reexport::axum::Json(body),
+                )
+                    .into_response()
+            }
+            CreateNaturalPersonIdentificationResponse::Default(default) => {
+                openapi_gen::axum_compat::default_response(default)
+            }
+        }
+    }
 }
 

--- a/tests/cases/allof_singleton/expect.rs
+++ b/tests/cases/allof_singleton/expect.rs
@@ -12,6 +12,7 @@
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct Id(pub openapi_gen::reexport::uuid::Uuid);
+openapi_gen::newtype_derive_canonical_form!(Id, openapi_gen::reexport::uuid::Uuid);
 type ThingId = Id;
 #[derive(
     Debug,

--- a/tests/cases/allof_singleton/expect.rs
+++ b/tests/cases/allof_singleton/expect.rs
@@ -47,4 +47,13 @@ pub struct WriteableThing {
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+}
 

--- a/tests/cases/basic_struct/expect.rs
+++ b/tests/cases/basic_struct/expect.rs
@@ -70,4 +70,13 @@ pub struct OuterStruct {
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+}
 

--- a/tests/cases/fancy_types/expect.rs
+++ b/tests/cases/fancy_types/expect.rs
@@ -109,4 +109,13 @@ pub struct Container {
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+}
 

--- a/tests/cases/item_ref/expect.rs
+++ b/tests/cases/item_ref/expect.rs
@@ -96,4 +96,38 @@ impl openapi_gen::reexport::axum::response::IntoResponse for PutThingResponse {
         }
     }
 }
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+        .route(
+            "/thing/:id",
+            openapi_gen::reexport::axum::routing::get({
+                let instance = instance.clone();
+                move |
+                    openapi_gen::reexport::axum::extract::Path(
+                        id,
+                    ): openapi_gen::reexport::axum::extract::Path<Id>|
+                async move { instance.get_thing(id).await }
+            }),
+        )
+        .route(
+            "/thing/:id",
+            openapi_gen::reexport::axum::routing::put({
+                let instance = instance.clone();
+                move |
+                    openapi_gen::reexport::axum::extract::Path(
+                        id,
+                    ): openapi_gen::reexport::axum::extract::Path<Id>,
+                    openapi_gen::reexport::axum::extract::Json(
+                        request_body,
+                    ): openapi_gen::reexport::axum::extract::Json<PutThingRequest>|
+                async move { instance.put_thing(id, request_body).await }
+            }),
+        )
+}
 

--- a/tests/cases/item_ref/expect.rs
+++ b/tests/cases/item_ref/expect.rs
@@ -69,4 +69,30 @@ Operation ID: `putThing`
 */
     async fn put_thing(&self, id: Id, request_body: PutThingRequest) -> PutThingResponse;
 }
+impl openapi_gen::reexport::axum::response::IntoResponse for GetThingResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            GetThingResponse::Ok(ok) => {
+                (
+                    openapi_gen::reexport::http::status::StatusCode::OK,
+                    openapi_gen::reexport::axum::Json(ok),
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+impl openapi_gen::reexport::axum::response::IntoResponse for PutThingResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            PutThingResponse::Ok(ok) => {
+                (
+                    openapi_gen::reexport::http::status::StatusCode::OK,
+                    openapi_gen::reexport::axum::Json(ok),
+                )
+                    .into_response()
+            }
+        }
+    }
+}
 

--- a/tests/cases/item_ref/expect.rs
+++ b/tests/cases/item_ref/expect.rs
@@ -12,6 +12,7 @@
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct Id(pub openapi_gen::reexport::uuid::Uuid);
+openapi_gen::newtype_derive_canonical_form!(Id, openapi_gen::reexport::uuid::Uuid);
 type Foo = f64;
 type Bar = String;
 #[derive(

--- a/tests/cases/kinds_of_nullability/expect.rs
+++ b/tests/cases/kinds_of_nullability/expect.rs
@@ -29,4 +29,13 @@ pub struct Foo {
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+}
 

--- a/tests/cases/member_rename/expect.rs
+++ b/tests/cases/member_rename/expect.rs
@@ -43,4 +43,13 @@ default casing is unexpected.
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+}
 

--- a/tests/cases/model_more_types/expect.rs
+++ b/tests/cases/model_more_types/expect.rs
@@ -11,6 +11,9 @@ pub type IsAwesome = bool;
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct ArbitraryJson(openapi_gen::reexport::serde_json::Value);
+openapi_gen::newtype_derive_canonical_form!(
+    ArbitraryJson, openapi_gen::reexport::serde_json::Value
+);
 #[derive(
     Debug,
     Clone,

--- a/tests/cases/model_more_types/expect.rs
+++ b/tests/cases/model_more_types/expect.rs
@@ -102,4 +102,13 @@ pub enum UntaggedEnum {
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+}
 

--- a/tests/cases/model_type_definitions/expect.rs
+++ b/tests/cases/model_type_definitions/expect.rs
@@ -40,4 +40,13 @@ pub struct Foo {
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+}
 

--- a/tests/cases/model_type_definitions/expect.rs
+++ b/tests/cases/model_type_definitions/expect.rs
@@ -18,6 +18,7 @@ pub type Count = u64;
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct FirstBar(pub String);
+openapi_gen::newtype_derive_canonical_form!(FirstBar, String);
 #[derive(
     Debug,
     Clone,

--- a/tests/cases/request_enum/expect.rs
+++ b/tests/cases/request_enum/expect.rs
@@ -114,4 +114,48 @@ impl openapi_gen::reexport::axum::response::IntoResponse for SameRequestResponse
         }
     }
 }
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+        .route(
+            "/multi-requests",
+            openapi_gen::reexport::axum::routing::post({
+                let instance = instance.clone();
+                move |
+                    openapi_gen::reexport::axum::extract::Json(
+                        request_body,
+                    ): openapi_gen::reexport::axum::extract::Json<MultiRequestsRequest>|
+                async move { instance.multi_requests(request_body).await }
+            }),
+        )
+        .route(
+            "/optional-request-body",
+            openapi_gen::reexport::axum::routing::post({
+                let instance = instance.clone();
+                move |
+                    openapi_gen::reexport::axum::extract::Json(
+                        request_body,
+                    ): openapi_gen::reexport::axum::extract::Json<
+                        OptionalRequestBodyRequest,
+                    >|
+                async move { instance.optional_request_body(request_body).await }
+            }),
+        )
+        .route(
+            "/unified-request-body",
+            openapi_gen::reexport::axum::routing::post({
+                let instance = instance.clone();
+                move |
+                    openapi_gen::reexport::axum::extract::Json(
+                        request_body,
+                    ): openapi_gen::reexport::axum::extract::Json<SameRequestRequest>|
+                async move { instance.same_request(request_body).await }
+            }),
+        )
+}
 

--- a/tests/cases/request_enum/expect.rs
+++ b/tests/cases/request_enum/expect.rs
@@ -86,4 +86,32 @@ Operation ID: `sameRequest`
         request_body: SameRequestRequest,
     ) -> SameRequestResponse;
 }
+impl openapi_gen::reexport::axum::response::IntoResponse for MultiRequestsResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            MultiRequestsResponse::Default(default) => {
+                openapi_gen::axum_compat::default_response(default)
+            }
+        }
+    }
+}
+impl openapi_gen::reexport::axum::response::IntoResponse
+for OptionalRequestBodyResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            OptionalRequestBodyResponse::Default(default) => {
+                openapi_gen::axum_compat::default_response(default)
+            }
+        }
+    }
+}
+impl openapi_gen::reexport::axum::response::IntoResponse for SameRequestResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            SameRequestResponse::Default(default) => {
+                openapi_gen::axum_compat::default_response(default)
+            }
+        }
+    }
+}
 

--- a/tests/cases/response_enum/expect.rs
+++ b/tests/cases/response_enum/expect.rs
@@ -8,7 +8,7 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
     Clone,
     PartialEq,
     openapi_gen::reexport::serde::Serialize,
-    openapi_gen::reexport::serde::Deserialize,
+    openapi_gen::reexport::serde::Deserialize
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum RenderPdfResponse {
@@ -24,41 +24,46 @@ pub enum RenderPdfResponse {
 pub trait Api {
     /**`POST /render`
 
-    Operation ID: `renderPdf`
+Operation ID: `renderPdf`
 
-    */
+*/
     async fn render_pdf(&self) -> RenderPdfResponse;
 }
 impl openapi_gen::reexport::axum::response::IntoResponse for RenderPdfResponse {
     fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
         match self {
             RenderPdfResponse::Ok(ok) => {
-                let mut header_map =
-                    openapi_gen::reexport::http::header::HeaderMap::with_capacity(1usize);
-                header_map.insert(
-                    openapi_gen::reexport::http::header::CONTENT_TYPE,
-                    openapi_gen::reexport::http::HeaderValue::from_static("application/pdf"),
+                let mut header_map = openapi_gen::reexport::http::header::HeaderMap::with_capacity(
+                    1usize,
                 );
+                header_map
+                    .insert(
+                        openapi_gen::reexport::http::header::CONTENT_TYPE,
+                        openapi_gen::reexport::http::HeaderValue::from_static(
+                            "application/pdf",
+                        ),
+                    );
+                (openapi_gen::reexport::http::status::StatusCode::OK, header_map, ok)
+                    .into_response()
+            }
+            RenderPdfResponse::BadRequest(bad_request) => {
                 (
-                    openapi_gen::reexport::http::status::StatusCode::OK,
-                    header_map,
-                    ok,
+                    openapi_gen::reexport::http::status::StatusCode::BAD_REQUEST,
+                    openapi_gen::reexport::axum::Json(bad_request),
                 )
                     .into_response()
             }
-            RenderPdfResponse::BadRequest(bad_request) => (
-                openapi_gen::reexport::http::status::StatusCode::BAD_REQUEST,
-                openapi_gen::reexport::axum::Json(bad_request),
-            )
-                .into_response(),
-            RenderPdfResponse::ServiceUnavailable(service_unavailable) => (
-                openapi_gen::reexport::http::status::StatusCode::SERVICE_UNAVAILABLE,
-                openapi_gen::reexport::axum::Json(service_unavailable),
-            )
-                .into_response(),
+            RenderPdfResponse::ServiceUnavailable(service_unavailable) => {
+                (
+                    openapi_gen::reexport::http::status::StatusCode::SERVICE_UNAVAILABLE,
+                    openapi_gen::reexport::axum::Json(service_unavailable),
+                )
+                    .into_response()
+            }
             RenderPdfResponse::Default(default) => {
                 openapi_gen::axum_compat::default_response(default)
             }
         }
     }
 }
+

--- a/tests/cases/response_enum/expect.rs
+++ b/tests/cases/response_enum/expect.rs
@@ -8,7 +8,7 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
     Clone,
     PartialEq,
     openapi_gen::reexport::serde::Serialize,
-    openapi_gen::reexport::serde::Deserialize
+    openapi_gen::reexport::serde::Deserialize,
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum RenderPdfResponse {
@@ -24,9 +24,41 @@ pub enum RenderPdfResponse {
 pub trait Api {
     /**`POST /render`
 
-Operation ID: `renderPdf`
+    Operation ID: `renderPdf`
 
-*/
+    */
     async fn render_pdf(&self) -> RenderPdfResponse;
 }
-
+impl openapi_gen::reexport::axum::response::IntoResponse for RenderPdfResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            RenderPdfResponse::Ok(ok) => {
+                let mut header_map =
+                    openapi_gen::reexport::http::header::HeaderMap::with_capacity(1usize);
+                header_map.insert(
+                    openapi_gen::reexport::http::header::CONTENT_TYPE,
+                    openapi_gen::reexport::http::HeaderValue::from_static("application/pdf"),
+                );
+                (
+                    openapi_gen::reexport::http::status::StatusCode::OK,
+                    header_map,
+                    ok,
+                )
+                    .into_response()
+            }
+            RenderPdfResponse::BadRequest(bad_request) => (
+                openapi_gen::reexport::http::status::StatusCode::BAD_REQUEST,
+                openapi_gen::reexport::axum::Json(bad_request),
+            )
+                .into_response(),
+            RenderPdfResponse::ServiceUnavailable(service_unavailable) => (
+                openapi_gen::reexport::http::status::StatusCode::SERVICE_UNAVAILABLE,
+                openapi_gen::reexport::axum::Json(service_unavailable),
+            )
+                .into_response(),
+            RenderPdfResponse::Default(default) => {
+                openapi_gen::axum_compat::default_response(default)
+            }
+        }
+    }
+}

--- a/tests/cases/response_enum/expect.rs
+++ b/tests/cases/response_enum/expect.rs
@@ -66,4 +66,20 @@ impl openapi_gen::reexport::axum::response::IntoResponse for RenderPdfResponse {
         }
     }
 }
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+        .route(
+            "/render",
+            openapi_gen::reexport::axum::routing::post({
+                let instance = instance.clone();
+                move || async move { instance.render_pdf().await }
+            }),
+        )
+}
 

--- a/tests/cases/trait_api/expect.rs
+++ b/tests/cases/trait_api/expect.rs
@@ -10,7 +10,7 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
     PartialEq,
     openapi_gen::reexport::serde::Serialize,
     openapi_gen::reexport::serde::Deserialize,
-    Eq,
+    Eq
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum PostKudosResponse {
@@ -21,16 +21,17 @@ pub enum PostKudosResponse {
 pub trait Api {
     /**`POST /post-kudos`
 
-    Operation ID: `postKudos`
+Operation ID: `postKudos`
 
-    */
+*/
     async fn post_kudos(&self, request_body: PostKudosRequest) -> PostKudosResponse;
 }
 impl openapi_gen::reexport::axum::response::IntoResponse for PostKudosResponse {
     fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
         match self {
             PostKudosResponse::Created(created) => {
-                openapi_gen::reexport::http::status::StatusCode::CREATED.into_response()
+                (openapi_gen::reexport::http::status::StatusCode::CREATED, created)
+                    .into_response()
             }
             PostKudosResponse::Default(default) => {
                 openapi_gen::axum_compat::default_response(default)
@@ -38,3 +39,4 @@ impl openapi_gen::reexport::axum::response::IntoResponse for PostKudosResponse {
         }
     }
 }
+

--- a/tests/cases/trait_api/expect.rs
+++ b/tests/cases/trait_api/expect.rs
@@ -39,4 +39,24 @@ impl openapi_gen::reexport::axum::response::IntoResponse for PostKudosResponse {
         }
     }
 }
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+        .route(
+            "/post-kudos",
+            openapi_gen::reexport::axum::routing::post({
+                let instance = instance.clone();
+                move |
+                    openapi_gen::reexport::axum::extract::Json(
+                        request_body,
+                    ): openapi_gen::reexport::axum::extract::Json<PostKudosRequest>|
+                async move { instance.post_kudos(request_body).await }
+            }),
+        )
+}
 

--- a/tests/cases/trait_api/expect.rs
+++ b/tests/cases/trait_api/expect.rs
@@ -10,7 +10,7 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
     PartialEq,
     openapi_gen::reexport::serde::Serialize,
     openapi_gen::reexport::serde::Deserialize,
-    Eq
+    Eq,
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum PostKudosResponse {
@@ -21,9 +21,20 @@ pub enum PostKudosResponse {
 pub trait Api {
     /**`POST /post-kudos`
 
-Operation ID: `postKudos`
+    Operation ID: `postKudos`
 
-*/
+    */
     async fn post_kudos(&self, request_body: PostKudosRequest) -> PostKudosResponse;
 }
-
+impl openapi_gen::reexport::axum::response::IntoResponse for PostKudosResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            PostKudosResponse::Created(created) => {
+                openapi_gen::reexport::http::status::StatusCode::CREATED.into_response()
+            }
+            PostKudosResponse::Default(default) => {
+                openapi_gen::axum_compat::default_response(default)
+            }
+        }
+    }
+}

--- a/tests/cases/well_known_type/expect.rs
+++ b/tests/cases/well_known_type/expect.rs
@@ -39,4 +39,26 @@ impl openapi_gen::reexport::axum::response::IntoResponse for PostWellKnownTypesR
         }
     }
 }
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+        .route(
+            "/well-known-types",
+            openapi_gen::reexport::axum::routing::post({
+                let instance = instance.clone();
+                move |
+                    openapi_gen::reexport::axum::extract::Json(
+                        request_body,
+                    ): openapi_gen::reexport::axum::extract::Json<
+                        PostWellKnownTypesRequest,
+                    >|
+                async move { instance.post_well_known_types(request_body).await }
+            }),
+        )
+}
 

--- a/tests/cases/well_known_type/expect.rs
+++ b/tests/cases/well_known_type/expect.rs
@@ -8,7 +8,7 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
     PartialEq,
     openapi_gen::reexport::serde::Serialize,
     openapi_gen::reexport::serde::Deserialize,
-    Eq,
+    Eq
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum PostWellKnownTypesResponse {
@@ -20,7 +20,7 @@ pub enum PostWellKnownTypesResponse {
 pub trait Api {
     /**`POST /well-known-types`
 
-    */
+*/
     async fn post_well_known_types(
         &self,
         request_body: PostWellKnownTypesRequest,
@@ -30,7 +30,8 @@ impl openapi_gen::reexport::axum::response::IntoResponse for PostWellKnownTypesR
     fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
         match self {
             PostWellKnownTypesResponse::NoContent(no_content) => {
-                openapi_gen::reexport::http::status::StatusCode::NO_CONTENT.into_response()
+                (openapi_gen::reexport::http::status::StatusCode::NO_CONTENT, no_content)
+                    .into_response()
             }
             PostWellKnownTypesResponse::Default(default) => {
                 openapi_gen::axum_compat::default_response(default)
@@ -38,3 +39,4 @@ impl openapi_gen::reexport::axum::response::IntoResponse for PostWellKnownTypesR
         }
     }
 }
+

--- a/tests/cases/well_known_type/expect.rs
+++ b/tests/cases/well_known_type/expect.rs
@@ -8,7 +8,7 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
     PartialEq,
     openapi_gen::reexport::serde::Serialize,
     openapi_gen::reexport::serde::Deserialize,
-    Eq
+    Eq,
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum PostWellKnownTypesResponse {
@@ -20,10 +20,21 @@ pub enum PostWellKnownTypesResponse {
 pub trait Api {
     /**`POST /well-known-types`
 
-*/
+    */
     async fn post_well_known_types(
         &self,
         request_body: PostWellKnownTypesRequest,
     ) -> PostWellKnownTypesResponse;
 }
-
+impl openapi_gen::reexport::axum::response::IntoResponse for PostWellKnownTypesResponse {
+    fn into_response(self) -> openapi_gen::reexport::axum::response::Response {
+        match self {
+            PostWellKnownTypesResponse::NoContent(no_content) => {
+                openapi_gen::reexport::http::status::StatusCode::NO_CONTENT.into_response()
+            }
+            PostWellKnownTypesResponse::Default(default) => {
+                openapi_gen::axum_compat::default_response(default)
+            }
+        }
+    }
+}

--- a/tests/cases/x_extensible_enum/expect.rs
+++ b/tests/cases/x_extensible_enum/expect.rs
@@ -21,4 +21,13 @@ pub enum DeliveryMethod {
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}
+/// Transform an instance of [`trait Api`][Api] into a [`Router`][axum::Router].
+pub fn build_router<Instance>(instance: Instance) -> openapi_gen::reexport::axum::Router
+where
+    Instance: 'static + Api + Send + Sync,
+{
+    #[allow(unused_variables)]
+    let instance = ::std::sync::Arc::new(instance);
+    openapi_gen::reexport::axum::Router::new()
+}
 


### PR DESCRIPTION
- [x] generate `IntoResponse` impls for response types
- [x] generate `Header` impls for types used as header parameters
- [x] generate `fn build_router`

For reference for these impls, see https://github.com/FINVIA/mono/pull/7763