### PR TITLE
avoid trivial type definitions

### DIFF
--- a/src/axum_compat/mod.rs
+++ b/src/axum_compat/mod.rs
@@ -13,7 +13,7 @@ use quote::quote;
 
 use crate::{
     axum_compat::{header::impl_header, into_response::impl_into_response},
-    codegen::{Scalar, Value},
+    codegen::{Reference, Scalar, UnknownReference, Value},
     ApiModel,
 };
 
@@ -23,7 +23,10 @@ mod into_response;
 
 pub use into_response::default_response;
 
-pub(crate) fn axum_items(model: &ApiModel) -> Result<TokenStream, Error> {
+pub(crate) fn axum_items<'a>(
+    model: &ApiModel,
+    name_resolver: impl Fn(Reference) -> Result<&'a str, UnknownReference>,
+) -> Result<TokenStream, Error> {
     let mut header_impls = Vec::new();
 
     for header_item in model.iter_items().filter_map(|ref_| {
@@ -44,7 +47,7 @@ pub(crate) fn axum_items(model: &ApiModel) -> Result<TokenStream, Error> {
         );
     }
 
-    let build_router = build_router::fn_build_router(model)?;
+    let build_router = build_router::fn_build_router(model, name_resolver)?;
 
     Ok(quote! {
         #( #header_impls )*

--- a/src/codegen/value/list.rs
+++ b/src/codegen/value/list.rs
@@ -1,6 +1,6 @@
-use crate::codegen::{
-    api_model::{Ref, Reference, UnknownReference},
-    make_ident,
+use crate::{
+    codegen::api_model::{Ref, Reference, UnknownReference},
+    ApiModel,
 };
 
 use proc_macro2::TokenStream;
@@ -29,10 +29,10 @@ impl List<Ref> {
 impl List {
     pub fn emit_definition<'a>(
         &self,
+        model: &ApiModel,
         name_resolver: impl Fn(Reference) -> Result<&'a str, UnknownReference>,
     ) -> Result<TokenStream, UnknownReference> {
-        let item_name = name_resolver(self.item)?;
-        let ident = make_ident(item_name);
-        Ok(quote!(Vec<#ident>))
+        let def = model.definition(self.item, name_resolver)?;
+        Ok(quote!(Vec<#def>))
     }
 }

--- a/src/codegen/value/map.rs
+++ b/src/codegen/value/map.rs
@@ -1,8 +1,5 @@
 use crate::{
-    codegen::{
-        api_model::{Ref, Reference, UnknownReference},
-        make_ident,
-    },
+    codegen::api_model::{Ref, Reference, UnknownReference},
     ApiModel,
 };
 
@@ -59,15 +56,12 @@ impl Map<Ref> {
 impl Map {
     pub fn emit_definition<'a>(
         &self,
+        model: &ApiModel,
         name_resolver: impl Fn(Reference) -> Result<&'a str, UnknownReference>,
     ) -> Result<TokenStream, UnknownReference> {
         let value_referent = self
             .value_type
-            .map(|reference| {
-                let item_name = name_resolver(reference)?;
-                let ident = make_ident(item_name);
-                Ok(quote!(#ident))
-            })
+            .map(|reference| model.definition(reference, name_resolver))
             .transpose()?
             .unwrap_or(quote!(openapi_gen::reexport::serde_json::Value));
         Ok(quote!(std::collections::HashMap<String, #value_referent>))

--- a/src/codegen/value/object.rs
+++ b/src/codegen/value/object.rs
@@ -84,7 +84,7 @@ impl ObjectMember {
         let mut snake_member_name = format!("{}", AsSnakeCase(member_name));
         model.deconflict_member_or_variant_ident(&mut snake_member_name);
         let snake_member_name = make_ident(&snake_member_name);
-        let item_ref = make_ident(name_resolver(self.definition)?);
+        let mut item_ref = model.definition(self.definition, name_resolver)?;
 
         if snake_member_name != member_name {
             serde_attributes.push(quote!(rename = #member_name));
@@ -92,7 +92,6 @@ impl ObjectMember {
 
         // `self.inline_option` is set when this item is optional, not intrinsically,
         // but within the context of this object.
-        let mut item_ref = quote!(#item_ref);
         if self.inline_option {
             item_ref = quote!(Option<#item_ref>);
             serde_attributes.push(quote!(skip_serializing_if = "Option::is_none"));

--- a/src/codegen/value/one_of_enum.rs
+++ b/src/codegen/value/one_of_enum.rs
@@ -200,6 +200,7 @@ impl OneOfEnum<Ref> {
 impl OneOfEnum {
     pub fn emit_definition<'a>(
         &self,
+        model: &ApiModel,
         name_resolver: impl Fn(Reference) -> Result<&'a str, UnknownReference>,
     ) -> Result<TokenStream, UnknownReference> {
         let variants = self
@@ -209,7 +210,7 @@ impl OneOfEnum {
             .map(|(idx, variant)| {
                 let variant_name = variant.compute_variant_name(idx, &name_resolver);
                 let ident = make_ident(variant_name);
-                let referent = make_ident(name_resolver(variant.definition)?);
+                let referent = model.definition(variant.definition, &name_resolver)?;
                 let attributes = variant.serde_attributes(variant_name);
                 let attributes =
                     (!attributes.is_empty()).then(|| quote!(#[serde( #( #attributes)* )]));

--- a/src/codegen/value/set.rs
+++ b/src/codegen/value/set.rs
@@ -1,6 +1,6 @@
-use crate::codegen::{
-    api_model::{Ref, Reference, UnknownReference},
-    make_ident,
+use crate::{
+    codegen::api_model::{Ref, Reference, UnknownReference},
+    ApiModel,
 };
 
 use proc_macro2::TokenStream;
@@ -29,10 +29,10 @@ impl Set<Ref> {
 impl Set {
     pub fn emit_definition<'a>(
         &self,
+        model: &ApiModel,
         name_resolver: impl Fn(Reference) -> Result<&'a str, UnknownReference>,
     ) -> Result<TokenStream, UnknownReference> {
-        let item_name = name_resolver(self.item)?;
-        let ident = make_ident(item_name);
-        Ok(quote!(std::collections::HashSet<#ident>))
+        let def = model.definition(self.item, name_resolver)?;
+        Ok(quote!(std::collections::HashSet<#def>))
     }
 }

--- a/tests/cases/18_response_value/expect.rs
+++ b/tests/cases/18_response_value/expect.rs
@@ -29,8 +29,7 @@ openapi_gen::newtype_derive_canonical_form!(
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct PersonId(pub openapi_gen::reexport::uuid::Uuid);
 openapi_gen::newtype_derive_canonical_form!(PersonId, openapi_gen::reexport::uuid::Uuid);
-type AdditionalInformationItem = String;
-pub type AdditionalInformation = Vec<AdditionalInformationItem>;
+pub type AdditionalInformation = Vec<String>;
 type Id = IdentificationId;
 #[derive(
     Debug,
@@ -49,7 +48,6 @@ pub struct NaturalPersonIdentification {
     pub id: Option<Id>,
     pub person_id: PersonId,
 }
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 #[derive(
     Debug,
     Clone,
@@ -90,7 +88,7 @@ pub struct CreateNaturalPersonIdentificationResponseCreated {
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum CreateNaturalPersonIdentificationResponse {
     Created(CreateNaturalPersonIdentificationResponseCreated),
-    Default(Default_),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {

--- a/tests/cases/24_headers/expect.rs
+++ b/tests/cases/24_headers/expect.rs
@@ -84,7 +84,6 @@ pub struct XRequestId(openapi_gen::reexport::uuid::Uuid);
 openapi_gen::newtype_derive_canonical_form!(
     XRequestId, openapi_gen::reexport::uuid::Uuid
 );
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 
 /// The path at which the new resource can be found.
 /// 
@@ -135,7 +134,7 @@ pub struct CreateNaturalPersonIdentificationResponseCreated {
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum CreateNaturalPersonIdentificationResponse {
     Created(CreateNaturalPersonIdentificationResponseCreated),
-    Default(Default_),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {

--- a/tests/cases/25_multiple_response_types/expect.rs
+++ b/tests/cases/25_multiple_response_types/expect.rs
@@ -36,8 +36,6 @@ pub struct DocumentId(pub openapi_gen::reexport::uuid::Uuid);
 openapi_gen::newtype_derive_canonical_form!(
     DocumentId, openapi_gen::reexport::uuid::Uuid
 );
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
-type Accept = openapi_gen::reexport::accept_header::Accept;
 ///Combination item for path parameters of `getNpIdentityDocumentData`
 #[derive(
     Debug,
@@ -62,8 +60,6 @@ pub struct GetNpIdentityDocumentDataPathParameters {
     #[serde(rename = "document-id")]
     pub document_id: DocumentId,
 }
-///document data encoded as base64
-type Data = openapi_gen::Bytes;
 #[derive(
     Debug,
     Clone,
@@ -78,11 +74,8 @@ type Data = openapi_gen::Bytes;
 pub struct OkApplicationJson {
     ///document data encoded as base64
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Data>,
+    pub data: Option<openapi_gen::Bytes>,
 }
-///raw document data
-type Ok_ = Vec<u8>;
-type NotAcceptable = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 #[derive(
     Debug,
     Clone,
@@ -96,10 +89,10 @@ pub enum GetNpIdentityDocumentDataResponse {
     #[serde(rename = "OK application/json")]
     OkApplicationJson(OkApplicationJson),
     #[serde(rename = "OK *")]
-    Ok(Ok_),
+    Ok(Vec<u8>),
     #[serde(rename = "Not Acceptable")]
-    NotAcceptable(NotAcceptable),
-    Default(Default_),
+    NotAcceptable(openapi_gen::reexport::http_api_problem::HttpApiProblem),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {
@@ -119,7 +112,7 @@ pub trait Api {
         &self,
         identification_id: IdentificationId,
         document_id: DocumentId,
-        accept: Option<Accept>,
+        accept: Option<openapi_gen::reexport::accept_header::Accept>,
     ) -> GetNpIdentityDocumentDataResponse;
 }
 impl openapi_gen::reexport::axum::response::IntoResponse
@@ -193,7 +186,9 @@ where
                         GetNpIdentityDocumentDataPathParameters,
                     >,
                     accept: Option<
-                        openapi_gen::reexport::axum::extract::TypedHeader<Accept>,
+                        openapi_gen::reexport::axum::extract::TypedHeader<
+                            openapi_gen::reexport::accept_header::Accept,
+                        >,
                     >|
                 async move {
                     let accept = accept.map(|accept| accept.0);

--- a/tests/cases/31_query_handler/expect.rs
+++ b/tests/cases/31_query_handler/expect.rs
@@ -1,8 +1,4 @@
 #![allow(non_camel_case_types)]
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
-type Bar = u64;
-type Bat = openapi_gen::reexport::uuid::Uuid;
-type CamelCaseName = String;
 ///Combination item for query parameters of `getRoot`
 #[derive(
     Debug,
@@ -17,12 +13,11 @@ type CamelCaseName = String;
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct GetRootQueryParameters {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bar: Option<Bar>,
-    pub bat: Bat,
+    pub bar: Option<u64>,
+    pub bat: openapi_gen::reexport::uuid::Uuid,
     #[serde(rename = "camelCaseName")]
-    pub camel_case_name: CamelCaseName,
+    pub camel_case_name: String,
 }
-type Ok_ = Vec<u8>;
 #[derive(
     Debug,
     Clone,
@@ -34,8 +29,8 @@ type Ok_ = Vec<u8>;
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum GetRootResponse {
     #[serde(rename = "OK")]
-    Ok(Ok_),
-    Default(Default_),
+    Ok(Vec<u8>),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {
@@ -45,9 +40,9 @@ pub trait Api {
     /// Operation ID: `getRoot`
     async fn get_root(
         &self,
-        bar: Option<Bar>,
-        bat: Bat,
-        camel_case_name: CamelCaseName,
+        bar: Option<u64>,
+        bat: openapi_gen::reexport::uuid::Uuid,
+        camel_case_name: String,
     ) -> GetRootResponse;
 }
 impl openapi_gen::reexport::axum::response::IntoResponse for GetRootResponse {

--- a/tests/cases/basic_struct/expect.rs
+++ b/tests/cases/basic_struct/expect.rs
@@ -1,7 +1,4 @@
 #![allow(non_camel_case_types)]
-///unsigned integer
-type Foo = u64;
-type Bar = String;
 ///this object is defined separately, intended to be used within a reference
 #[derive(
     Debug,
@@ -16,18 +13,10 @@ type Bar = String;
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct InnerStruct {
     ///unsigned integer
-    pub foo: Foo,
+    pub foo: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bar: Option<Bar>,
+    pub bar: Option<String>,
 }
-
-/// even given compatible names and types, distinct inline types are distinguished.
-/// the software makes no attempt to unify the types, because that would violate the
-/// principle of least surprise.
-/// 
-/// for type unification, use a reference.
-type DefinedInlineFoo = u64;
-type Bat = i64;
 ///this object is defined inline within `OuterStruct`
 #[derive(
     Debug,
@@ -48,8 +37,8 @@ pub struct DefinedInline {
     /// principle of least surprise.
     /// 
     /// for type unification, use a reference.
-    pub foo: DefinedInlineFoo,
-    pub bat: Bat,
+    pub foo: u64,
+    pub bat: i64,
 }
 #[derive(
     Debug,

--- a/tests/cases/deduplicate_options_in_query_params/expect.rs
+++ b/tests/cases/deduplicate_options_in_query_params/expect.rs
@@ -36,7 +36,6 @@ pub enum Status {
     #[serde(other)]
     Other(String),
 }
-type Foo = String;
 #[derive(
     Debug,
     Clone,
@@ -52,13 +51,12 @@ pub struct Item {
     ///an identifier for an item
     pub id: Id,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub foo: Option<Foo>,
+    pub foo: Option<String>,
 
     /// An item's status
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<Status>,
 }
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 #[derive(
     Debug,
     Clone,
@@ -109,7 +107,7 @@ type Ok_ = Vec<Item>;
 pub enum GetListResponse {
     #[serde(rename = "OK")]
     Ok(Ok_),
-    Default(Default_),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {

--- a/tests/cases/fancy_types/expect.rs
+++ b/tests/cases/fancy_types/expect.rs
@@ -1,69 +1,4 @@
 #![allow(non_camel_case_types)]
-type Number = f64;
-type NumberFloat = f32;
-type NumberDouble = f64;
-type Integer = i64;
-type IntegerI32 = i32;
-type IntegerI64 = i64;
-type UnsignedInteger = u64;
-type UnsignedIntegerI32 = u32;
-type UnsignedIntegerI64 = u64;
-type BoundedIntegerLow = openapi_gen::reexport::bounded_integer::BoundedI64<
-    1i64,
-    9223372036854775807i64,
->;
-type BoundedIntegerHigh = openapi_gen::reexport::bounded_integer::BoundedI64<
-    -9223372036854775808i64,
-    5i64,
->;
-type BoundedIntegerBoth = openapi_gen::reexport::bounded_integer::BoundedI64<0i64, 5i64>;
-type ExclusiveBoundedIntegerLow = openapi_gen::reexport::bounded_integer::BoundedI64<
-    2i64,
-    9223372036854775807i64,
->;
-type ExclusiveBoundedIntegerHigh = openapi_gen::reexport::bounded_integer::BoundedI64<
-    -9223372036854775808i64,
-    4i64,
->;
-type ExclusiveBoundedIntegerBoth = openapi_gen::reexport::bounded_integer::BoundedI64<
-    1i64,
-    4i64,
->;
-type BoundedIntegerLowI32 = openapi_gen::reexport::bounded_integer::BoundedI32<
-    1i32,
-    2147483647i32,
->;
-type BoundedIntegerHighI32 = openapi_gen::reexport::bounded_integer::BoundedI32<
-    -2147483648i32,
-    5i32,
->;
-type BoundedIntegerBothI32 = openapi_gen::reexport::bounded_integer::BoundedI32<
-    0i32,
-    5i32,
->;
-type ExclusiveBoundedIntegerLowI32 = openapi_gen::reexport::bounded_integer::BoundedI32<
-    2i32,
-    2147483647i32,
->;
-type ExclusiveBoundedIntegerHighI32 = openapi_gen::reexport::bounded_integer::BoundedI32<
-    -2147483648i32,
-    4i32,
->;
-type ExclusiveBoundedIntegerBothI32 = openapi_gen::reexport::bounded_integer::BoundedI32<
-    1i32,
-    4i32,
->;
-type String_ = String;
-type StringBinary = Vec<u8>;
-type StringByte = openapi_gen::Bytes;
-type StringBase64 = openapi_gen::Bytes;
-type StringDate = openapi_gen::reexport::time::Date;
-type StringDatetime = openapi_gen::reexport::time::OffsetDateTime;
-type StringIp = std::net::IpAddr;
-type StringIpv4 = std::net::Ipv4Addr;
-type StringIpv6 = std::net::Ipv6Addr;
-type StringUuid = openapi_gen::reexport::uuid::Uuid;
-type StringUnrecognized = String;
 #[derive(
     Debug,
     Clone,
@@ -74,38 +9,74 @@ type StringUnrecognized = String;
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct Container {
-    pub number: Number,
-    pub number_float: NumberFloat,
-    pub number_double: NumberDouble,
-    pub integer: Integer,
-    pub integer_i32: IntegerI32,
-    pub integer_i64: IntegerI64,
-    pub unsigned_integer: UnsignedInteger,
-    pub unsigned_integer_i32: UnsignedIntegerI32,
-    pub unsigned_integer_i64: UnsignedIntegerI64,
-    pub bounded_integer_low: BoundedIntegerLow,
-    pub bounded_integer_high: BoundedIntegerHigh,
-    pub bounded_integer_both: BoundedIntegerBoth,
-    pub exclusive_bounded_integer_low: ExclusiveBoundedIntegerLow,
-    pub exclusive_bounded_integer_high: ExclusiveBoundedIntegerHigh,
-    pub exclusive_bounded_integer_both: ExclusiveBoundedIntegerBoth,
-    pub bounded_integer_low_i32: BoundedIntegerLowI32,
-    pub bounded_integer_high_i32: BoundedIntegerHighI32,
-    pub bounded_integer_both_i32: BoundedIntegerBothI32,
-    pub exclusive_bounded_integer_low_i32: ExclusiveBoundedIntegerLowI32,
-    pub exclusive_bounded_integer_high_i32: ExclusiveBoundedIntegerHighI32,
-    pub exclusive_bounded_integer_both_i32: ExclusiveBoundedIntegerBothI32,
-    pub string: String_,
-    pub string_binary: StringBinary,
-    pub string_byte: StringByte,
-    pub string_base64: StringBase64,
-    pub string_date: StringDate,
-    pub string_datetime: StringDatetime,
-    pub string_ip: StringIp,
-    pub string_ipv4: StringIpv4,
-    pub string_ipv6: StringIpv6,
-    pub string_uuid: StringUuid,
-    pub string_unrecognized: StringUnrecognized,
+    pub number: f64,
+    pub number_float: f32,
+    pub number_double: f64,
+    pub integer: i64,
+    pub integer_i32: i32,
+    pub integer_i64: i64,
+    pub unsigned_integer: u64,
+    pub unsigned_integer_i32: u32,
+    pub unsigned_integer_i64: u64,
+    pub bounded_integer_low: openapi_gen::reexport::bounded_integer::BoundedI64<
+        1i64,
+        9223372036854775807i64,
+    >,
+    pub bounded_integer_high: openapi_gen::reexport::bounded_integer::BoundedI64<
+        -9223372036854775808i64,
+        5i64,
+    >,
+    pub bounded_integer_both: openapi_gen::reexport::bounded_integer::BoundedI64<
+        0i64,
+        5i64,
+    >,
+    pub exclusive_bounded_integer_low: openapi_gen::reexport::bounded_integer::BoundedI64<
+        2i64,
+        9223372036854775807i64,
+    >,
+    pub exclusive_bounded_integer_high: openapi_gen::reexport::bounded_integer::BoundedI64<
+        -9223372036854775808i64,
+        4i64,
+    >,
+    pub exclusive_bounded_integer_both: openapi_gen::reexport::bounded_integer::BoundedI64<
+        1i64,
+        4i64,
+    >,
+    pub bounded_integer_low_i32: openapi_gen::reexport::bounded_integer::BoundedI32<
+        1i32,
+        2147483647i32,
+    >,
+    pub bounded_integer_high_i32: openapi_gen::reexport::bounded_integer::BoundedI32<
+        -2147483648i32,
+        5i32,
+    >,
+    pub bounded_integer_both_i32: openapi_gen::reexport::bounded_integer::BoundedI32<
+        0i32,
+        5i32,
+    >,
+    pub exclusive_bounded_integer_low_i32: openapi_gen::reexport::bounded_integer::BoundedI32<
+        2i32,
+        2147483647i32,
+    >,
+    pub exclusive_bounded_integer_high_i32: openapi_gen::reexport::bounded_integer::BoundedI32<
+        -2147483648i32,
+        4i32,
+    >,
+    pub exclusive_bounded_integer_both_i32: openapi_gen::reexport::bounded_integer::BoundedI32<
+        1i32,
+        4i32,
+    >,
+    pub string: String,
+    pub string_binary: Vec<u8>,
+    pub string_byte: openapi_gen::Bytes,
+    pub string_base64: openapi_gen::Bytes,
+    pub string_date: openapi_gen::reexport::time::Date,
+    pub string_datetime: openapi_gen::reexport::time::OffsetDateTime,
+    pub string_ip: std::net::IpAddr,
+    pub string_ipv4: std::net::Ipv4Addr,
+    pub string_ipv6: std::net::Ipv6Addr,
+    pub string_uuid: openapi_gen::reexport::uuid::Uuid,
+    pub string_unrecognized: String,
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}

--- a/tests/cases/item_ref/expect.rs
+++ b/tests/cases/item_ref/expect.rs
@@ -13,8 +13,6 @@
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct Id(pub openapi_gen::reexport::uuid::Uuid);
 openapi_gen::newtype_derive_canonical_form!(Id, openapi_gen::reexport::uuid::Uuid);
-type Foo = f64;
-type Bar = String;
 #[derive(
     Debug,
     Clone,
@@ -26,9 +24,9 @@ type Bar = String;
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct Thing {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub foo: Option<Foo>,
+    pub foo: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bar: Option<Bar>,
+    pub bar: Option<String>,
 }
 ///Combination item for path parameters of `getThing`
 #[derive(

--- a/tests/cases/kinds_of_nullability/expect.rs
+++ b/tests/cases/kinds_of_nullability/expect.rs
@@ -1,11 +1,4 @@
 #![allow(non_camel_case_types)]
-type NotNullableAndRequired = i64;
-type NotNullableAndNotRequired = i64;
-type MaybeNullableAndRequired = Option<NullableAndRequired>;
-type NullableAndRequired = i64;
-type MaybeNullableAndNotRequired = Option<NullableAndNotRequired>;
-///note that this produces an `Option<Option<_>>`
-type NullableAndNotRequired = i64;
 #[derive(
     Debug,
     Clone,
@@ -19,13 +12,13 @@ type NullableAndNotRequired = i64;
 )]
 #[serde(crate = "openapi_gen::reexport::serde")]
 pub struct Foo {
-    pub not_nullable_and_required: NotNullableAndRequired,
+    pub not_nullable_and_required: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub not_nullable_and_not_required: Option<NotNullableAndNotRequired>,
-    pub nullable_and_required: MaybeNullableAndRequired,
+    pub not_nullable_and_not_required: Option<i64>,
+    pub nullable_and_required: Option<i64>,
     ///note that this produces an `Option<Option<_>>`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nullable_and_not_required: Option<MaybeNullableAndNotRequired>,
+    pub nullable_and_not_required: Option<Option<i64>>,
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}

--- a/tests/cases/member_rename/expect.rs
+++ b/tests/cases/member_rename/expect.rs
@@ -1,17 +1,4 @@
 #![allow(non_camel_case_types)]
-///who this gift is for
-type For = String;
-
-/// who this gift is from.
-/// 
-/// May be omitted for anonymous gifting.
-type From_ = String;
-
-/// a teaser message to excite the imagination before opening the gift.
-/// 
-/// The point is to see if the rename attribute is emitted appropriately if the
-/// default casing is unexpected.
-type Message = String;
 #[derive(
     Debug,
     Clone,
@@ -26,20 +13,20 @@ type Message = String;
 pub struct GiftTag {
     ///who this gift is for
     #[serde(rename = "for")]
-    pub for_: For,
+    pub for_: String,
 
     /// who this gift is from.
     /// 
     /// May be omitted for anonymous gifting.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub from: Option<From_>,
+    pub from: Option<String>,
 
     /// a teaser message to excite the imagination before opening the gift.
     /// 
     /// The point is to see if the rename attribute is emitted appropriately if the
     /// default casing is unexpected.
     #[serde(rename = "Message", skip_serializing_if = "Option::is_none")]
-    pub message: Option<Message>,
+    pub message: Option<String>,
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {}

--- a/tests/cases/model_more_types/expect.rs
+++ b/tests/cases/model_more_types/expect.rs
@@ -29,8 +29,7 @@ pub struct Thing {
     pub data: ArbitraryJson,
 }
 pub type List = Vec<Thing>;
-type SetItem = i64;
-pub type Set = std::collections::HashSet<SetItem>;
+pub type Set = std::collections::HashSet<i64>;
 pub type Map = std::collections::HashMap<String, Thing>;
 ///sort order
 #[derive(

--- a/tests/cases/request_enum/expect.rs
+++ b/tests/cases/request_enum/expect.rs
@@ -2,7 +2,6 @@
 pub type JsonType = openapi_gen::reexport::serde_json::Value;
 pub type FormType = openapi_gen::reexport::serde_json::Value;
 pub type ReqType = openapi_gen::reexport::serde_json::Value;
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 pub type ApplicationJson = JsonType;
 pub type MultipartFormValue = openapi_gen::reexport::serde_json::Value;
 #[derive(
@@ -27,7 +26,7 @@ pub enum MultiRequestsRequest {
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum MultiRequestsResponse {
-    Default(Default_),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 ///request body is optional
 pub type OptionalRequestBodyRequest = Option<JsonType>;
@@ -41,7 +40,7 @@ pub type OptionalRequestBodyRequest = Option<JsonType>;
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum OptionalRequestBodyResponse {
-    Default(Default_),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 pub type SameRequestRequest = ReqType;
 #[derive(
@@ -54,7 +53,7 @@ pub type SameRequestRequest = ReqType;
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum SameRequestResponse {
-    Default(Default_),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {

--- a/tests/cases/response_enum/expect.rs
+++ b/tests/cases/response_enum/expect.rs
@@ -1,8 +1,5 @@
 #![allow(non_camel_case_types)]
 pub type RenderError = openapi_gen::reexport::serde_json::Value;
-type Ok_ = Vec<u8>;
-type ServiceUnavailable = openapi_gen::reexport::http_api_problem::HttpApiProblem;
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 #[derive(
     Debug,
     Clone,
@@ -13,12 +10,12 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum RenderPdfResponse {
     #[serde(rename = "OK")]
-    Ok(Ok_),
+    Ok(Vec<u8>),
     #[serde(rename = "Bad Request")]
     BadRequest(RenderError),
     #[serde(rename = "Service Unavailable")]
-    ServiceUnavailable(ServiceUnavailable),
-    Default(Default_),
+    ServiceUnavailable(openapi_gen::reexport::http_api_problem::HttpApiProblem),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {

--- a/tests/cases/trait_api/expect.rs
+++ b/tests/cases/trait_api/expect.rs
@@ -2,8 +2,6 @@
 pub type PostKudo = openapi_gen::reexport::serde_json::Value;
 ///request body for a freeform render request
 pub type PostKudosRequest = PostKudo;
-type Created = ();
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 #[derive(
     Debug,
     Clone,
@@ -14,8 +12,8 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 )]
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum PostKudosResponse {
-    Created(Created),
-    Default(Default_),
+    Created(()),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {

--- a/tests/cases/well_known_type/expect.rs
+++ b/tests/cases/well_known_type/expect.rs
@@ -1,7 +1,5 @@
 #![allow(non_camel_case_types)]
 pub type PostWellKnownTypesRequest = openapi_gen::reexport::serde_json::Value;
-type NoContent = ();
-type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 #[derive(
     Debug,
     Clone,
@@ -13,8 +11,8 @@ type Default_ = openapi_gen::reexport::http_api_problem::HttpApiProblem;
 #[serde(crate = "openapi_gen::reexport::serde", tag = "status")]
 pub enum PostWellKnownTypesResponse {
     #[serde(rename = "No Content")]
-    NoContent(NoContent),
-    Default(Default_),
+    NoContent(()),
+    Default(openapi_gen::reexport::http_api_problem::HttpApiProblem),
 }
 #[openapi_gen::reexport::async_trait::async_trait]
 pub trait Api {


### PR DESCRIPTION
Previously, we'd been generating a named newtype for every `Item`. This works, but is hard to reason about. It's much simpler to work with an `Option<String>` than a `MaybeFoo`, given that you have to first look up that `type MaybeFoo = Option<Foo>` and `type Foo = String`.

Further, it was causing explicit bugs: we saw cases like

```rust
type Foo = String;
type MaybeFoo = Option<Foo>;
type Foo = String;
type MaybeFoo1 = Option<Foo>;
```

In other words, we were deconflicting the containers, but not the contained attributes.

This PR updates things to avoid such trivial type definitions; they all get inlined now.

- reduces size of generated code
- simplifies generated code for human reviewers
- eliminates a category of codegen bug