### PR TITLE
Use `serde_as` where appropriate to derive serialization helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,7 +598,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -613,6 +619,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "headers"
@@ -804,6 +816,17 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
  "serde",
 ]
 
@@ -1014,7 +1037,7 @@ dependencies = [
  "heck",
  "http",
  "http-api-problem",
- "indexmap",
+ "indexmap 1.9.3",
  "md-5",
  "mime",
  "openapiv3-extended",
@@ -1046,7 +1069,7 @@ checksum = "bf07a12429ed706dfd6cb2e1a497b664b9a3c54d796b5adda101e3cf02a1a7f4"
 dependencies = [
  "anyhow",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_json",
 ]
@@ -1423,14 +1446,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
 dependencies = [
  "base64 0.21.0",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -1439,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
+checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
 dependencies = [
  "darling 0.20.1",
  "proc-macro2",
@@ -1455,7 +1479,7 @@ version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ reqwest = { version = "0.11.18", features = ["blocking"] }
 serde = { version = "1.0.163", features = ["derive"] }
 serde-enum-str = "0.4.0"
 serde_json = "1.0.96"
-serde_with = { version = "3.0.0", optional = true }
+serde_with = { version = "3.2.0" }
 serde_yaml = { version = "0.9.21", optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
 syn = "2.0.15"
@@ -50,7 +50,7 @@ default = []
 api-problem = ["http-api-problem"]
 axum-support = ["axum", "headers"]
 cli = ["clap", "serde_yaml"]
-bytes = ["base64", "serde_with"]
+bytes = ["base64"]
 integer-restrictions = ["bounded-integer"]
 scripts = ["cli"]
 string-pattern = ["regress"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ reqwest = { version = "0.11.18", features = ["blocking"] }
 serde = { version = "1.0.163", features = ["derive"] }
 serde-enum-str = "0.4.0"
 serde_json = "1.0.96"
-serde_with = { version = "3.2.0" }
+serde_with = { version = "3.2.0", features = ["macros"] }
 serde_yaml = { version = "0.9.21", optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
 syn = "2.0.15"

--- a/src/codegen/api_model.rs
+++ b/src/codegen/api_model.rs
@@ -596,6 +596,28 @@ impl ApiModel<Ref> {
     }
 }
 
+/// Generic implementations using the `AsBackref` trait are more flexible than using the more specialized versions above.
+#[allow(dead_code)]
+impl<R> ApiModel<R> {
+    #[inline]
+    pub(crate) fn resolve_as_backref(&self, ref_: &R) -> Option<&Item<R>>
+    where
+        R: AsBackref,
+    {
+        let backref = ref_.as_backref()?;
+        self.definitions.get(backref)
+    }
+
+    #[inline]
+    pub(crate) fn resolve_as_backref_mut(&mut self, ref_: &R) -> Option<&mut Item<R>>
+    where
+        R: AsBackref,
+    {
+        let backref = ref_.as_backref()?;
+        self.definitions.get_mut(backref)
+    }
+}
+
 impl ApiModel {
     pub fn new(spec: &OpenAPI, input_file: Option<impl AsRef<Path>>) -> Result<Self, Error> {
         let input_file = input_file.map(|path_ref| path_ref.as_ref().to_owned());

--- a/src/codegen/api_model.rs
+++ b/src/codegen/api_model.rs
@@ -609,28 +609,6 @@ where
     }
 }
 
-/// Generic implementations using the `AsBackref` trait are more flexible than using the more specialized versions above.
-#[allow(dead_code)]
-impl<R> ApiModel<R> {
-    #[inline]
-    pub(crate) fn resolve_as_backref(&self, ref_: &R) -> Option<&Item<R>>
-    where
-        R: AsBackref,
-    {
-        let backref = ref_.as_backref()?;
-        self.definitions.get(backref)
-    }
-
-    #[inline]
-    pub(crate) fn resolve_as_backref_mut(&mut self, ref_: &R) -> Option<&mut Item<R>>
-    where
-        R: AsBackref,
-    {
-        let backref = ref_.as_backref()?;
-        self.definitions.get_mut(backref)
-    }
-}
-
 impl ApiModel {
     pub fn new(spec: &OpenAPI, input_file: Option<impl AsRef<Path>>) -> Result<Self, Error> {
         let input_file = input_file.map(|path_ref| path_ref.as_ref().to_owned());

--- a/src/codegen/item.rs
+++ b/src/codegen/item.rs
@@ -410,7 +410,7 @@ impl Item {
         let serde_as = self
             .value
             .use_serde_as_annotation(model)
-            .then(|| quote!(#[openapi_gen::reexport::serde_with::serde_as]));
+            .then(|| quote!(#[openapi_gen::reexport::serde_with::serde_as(crate = "openapi_gen::reexport::serde_with")]));
 
         let derives = (!self.is_typedef())
             .then(|| self.derives(model))

--- a/src/codegen/item.rs
+++ b/src/codegen/item.rs
@@ -47,7 +47,9 @@ fn is_property_singleton(
     schema: &Schema,
 ) -> bool {
     // the schema is a property sub-schema of an object type
-    let Some((object_type, property_name)) = containing_object else {return false};
+    let Some((object_type, property_name)) = containing_object else {
+        return false;
+    };
     if object_type
         .properties
         .get(property_name)
@@ -67,7 +69,9 @@ fn is_property_singleton(
     }
 
     // the schema has an `allOf` definition
-    let SchemaKind::AllOf { all_of } = &schema.schema_kind else {return false};
+    let SchemaKind::AllOf { all_of } = &schema.schema_kind else {
+        return false;
+    };
 
     // the `allOf` definition possesses exactly one item
     if all_of.len() != 1 {
@@ -364,6 +368,11 @@ impl Item {
         let equals =
             (self.newtype.is_none() && !self.value.is_struct_or_enum()).then_some(quote!(=));
 
+        let serde_as = self
+            .value
+            .use_serde_as_annotation(model)
+            .then(|| quote!(#[openapi_gen::reexport::serde_with::serde_as]));
+
         let derives = (!self.is_typedef())
             .then(|| self.derives(model))
             .and_then(|derives| (!derives.is_empty()).then_some(derives))
@@ -418,6 +427,7 @@ impl Item {
             #wrapper_def
 
             #docs
+            #serde_as
             #derives
             #serde_container_attributes
             #pub_ #item_keyword #item_ident #equals #item_def #semicolon

--- a/src/codegen/item.rs
+++ b/src/codegen/item.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use heck::ToUpperCamelCase;
 use openapiv3::{ObjectType, OpenAPI, Schema, SchemaKind, Type};
 use proc_macro2::TokenStream;
@@ -12,7 +14,7 @@ use crate::{
     resolve_trait::Resolve,
 };
 
-use super::{OneOfEnum, StringEnum};
+use super::{api_model::AsBackref, OneOfEnum, StringEnum};
 
 // note: openapiv3 intentionally ignores extensions whose name does not start with "x-".
 fn get_extension_value<'a>(schema: &'a Schema, key: &str) -> Option<&'a serde_json::Value> {
@@ -159,6 +161,19 @@ impl<R> Default for Item<R> {
             content_type: Default::default(),
             impl_header: Default::default(),
         }
+    }
+}
+
+impl<R> Item<R>
+where
+    R: AsBackref + fmt::Debug,
+{
+    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream> {
+        let mut vd = self.value.use_display_from_str(model)?;
+        if self.nullable {
+            vd = quote!(Option<#vd>);
+        }
+        Some(vd)
     }
 }
 

--- a/src/codegen/value/list.rs
+++ b/src/codegen/value/list.rs
@@ -13,15 +13,21 @@ pub struct List<Ref = Reference> {
     pub item: Ref,
 }
 
-impl<R> List<R> {
-    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
-    where
-        R: AsBackref + fmt::Debug,
-    {
+impl<R> List<R>
+where
+    R: AsBackref + fmt::Debug,
+{
+    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool {
         let Ok(item) = model.resolve(&self.item) else {
             return false;
         };
-        item.value.use_display_from_str(model)
+        item.use_display_from_str(model).is_some()
+    }
+
+    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream> {
+        let item = model.resolve(&self.item).ok()?;
+        let inner = item.use_display_from_str(model)?;
+        Some(quote!(Vec<#inner>))
     }
 }
 

--- a/src/codegen/value/list.rs
+++ b/src/codegen/value/list.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{
     codegen::api_model::{AsBackref, Ref, Reference, UnknownReference},
     ApiModel,
@@ -14,9 +16,9 @@ pub struct List<Ref = Reference> {
 impl<R> List<R> {
     pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
     where
-        R: AsBackref,
+        R: AsBackref + fmt::Debug,
     {
-        let Some(item) = model.resolve_as_backref(&self.item) else {
+        let Ok(item) = model.resolve(&self.item) else {
             return false;
         };
         item.value.use_display_from_str(model)

--- a/src/codegen/value/list.rs
+++ b/src/codegen/value/list.rs
@@ -1,6 +1,9 @@
-use crate::codegen::{
-    api_model::{Ref, Reference, UnknownReference},
-    make_ident,
+use crate::{
+    codegen::{
+        api_model::{AsBackref, Ref, Reference, UnknownReference},
+        make_ident,
+    },
+    ApiModel,
 };
 
 use proc_macro2::TokenStream;
@@ -9,6 +12,18 @@ use quote::quote;
 #[derive(Debug, Clone)]
 pub struct List<Ref = Reference> {
     pub item: Ref,
+}
+
+impl<R> List<R> {
+    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
+    where
+        R: AsBackref,
+    {
+        let Some(item) = model.resolve_as_backref(&self.item) else {
+            return false;
+        };
+        item.value.use_display_from_str(model)
+    }
 }
 
 impl List<Ref> {

--- a/src/codegen/value/map.rs
+++ b/src/codegen/value/map.rs
@@ -1,6 +1,6 @@
 use crate::{
     codegen::{
-        api_model::{Ref, Reference, UnknownReference},
+        api_model::{AsBackref, Ref, Reference, UnknownReference},
         make_ident,
     },
     ApiModel,
@@ -16,6 +16,23 @@ use super::ValueConversionError;
 #[derive(Debug, Clone)]
 pub struct Map<Ref = Reference> {
     pub value_type: Option<Ref>,
+}
+
+impl<R> Map<R> {
+    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
+    where
+        R: AsBackref,
+    {
+        self.value_type
+            .as_ref()
+            .map(|value_type_ref| {
+                let Some(item) = model.resolve_as_backref(value_type_ref) else {
+                    return false;
+                };
+                item.value.use_display_from_str(model)
+            })
+            .unwrap_or_default()
+    }
 }
 
 impl Map<Ref> {

--- a/src/codegen/value/map.rs
+++ b/src/codegen/value/map.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{
     codegen::api_model::{AsBackref, Ref, Reference, UnknownReference},
     ApiModel,
@@ -18,12 +20,12 @@ pub struct Map<Ref = Reference> {
 impl<R> Map<R> {
     pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
     where
-        R: AsBackref,
+        R: AsBackref + fmt::Debug,
     {
         self.value_type
             .as_ref()
             .map(|value_type_ref| {
-                let Some(item) = model.resolve_as_backref(value_type_ref) else {
+                let Ok(item) = model.resolve(value_type_ref) else {
                     return false;
                 };
                 item.value.use_display_from_str(model)

--- a/src/codegen/value/map.rs
+++ b/src/codegen/value/map.rs
@@ -17,20 +17,26 @@ pub struct Map<Ref = Reference> {
     pub value_type: Option<Ref>,
 }
 
-impl<R> Map<R> {
-    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
-    where
-        R: AsBackref + fmt::Debug,
-    {
+impl<R> Map<R>
+where
+    R: AsBackref + fmt::Debug,
+{
+    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool {
         self.value_type
             .as_ref()
             .map(|value_type_ref| {
                 let Ok(item) = model.resolve(value_type_ref) else {
                     return false;
                 };
-                item.value.use_display_from_str(model)
+                item.use_display_from_str(model).is_some()
             })
             .unwrap_or_default()
+    }
+
+    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream> {
+        let item = model.resolve(self.value_type.as_ref()?).ok()?;
+        let inner = item.use_display_from_str(model)?;
+        Some(quote!(std::collections::HashMap<String, #inner>))
     }
 }
 

--- a/src/codegen/value/mod.rs
+++ b/src/codegen/value/mod.rs
@@ -277,6 +277,20 @@ impl<R> Value<R> {
             _ => None,
         }
     }
+
+    pub fn use_serde_as_annotation(&self, model: &ApiModel) -> bool {
+        match self {
+            Value::StringEnum(_) => false,
+            Value::Scalar(scalar) => scalar.use_display_from_str(),
+            Value::OneOfEnum(oo_enum) => oo_enum.use_serde_as_annotation(model),
+            Value::Set(_) => todo!(),
+            Value::List(_) => todo!(),
+            Value::Object(_) => todo!(),
+            Value::Map(_) => todo!(),
+            Value::Ref(_) => todo!(),
+            Value::PropertyOverride(_) => todo!(),
+        }
+    }
 }
 
 impl Value {

--- a/src/codegen/value/mod.rs
+++ b/src/codegen/value/mod.rs
@@ -315,7 +315,7 @@ impl<R> Value<R> {
 
     pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
     where
-        R: AsBackref,
+        R: AsBackref + fmt::Debug,
     {
         match self {
             Value::StringEnum(_) | Value::Scalar(_) => false,
@@ -325,7 +325,7 @@ impl<R> Value<R> {
             Value::Object(object) => object.use_serde_as_annotation(model),
             Value::Map(map) => map.use_serde_as_annotation(model),
             Value::Ref(ref_) | Value::PropertyOverride(PropertyOverride { ref_, .. }) => {
-                let Some(item) = model.resolve_as_backref(ref_) else {
+                let Ok(item) = model.resolve(ref_) else {
                     return false;
                 };
                 item.value.use_display_from_str(model)

--- a/src/codegen/value/object.rs
+++ b/src/codegen/value/object.rs
@@ -1,5 +1,5 @@
 use crate::codegen::{
-    api_model::{Ref, Reference, UnknownReference},
+    api_model::{AsBackref, Ref, Reference, UnknownReference},
     make_ident, ApiModel, PropertyOverride,
 };
 
@@ -134,6 +134,20 @@ impl<R> Default for Object<R> {
             members: Default::default(),
             is_generated_body_and_headers: Default::default(),
         }
+    }
+}
+
+impl<R> Object<R> {
+    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
+    where
+        R: AsBackref,
+    {
+        self.members.values().any(|member| {
+            let Some(item) = model.resolve_as_backref(&member.definition) else {
+                return false;
+            };
+            item.value.use_display_from_str(model)
+        })
     }
 }
 

--- a/src/codegen/value/object.rs
+++ b/src/codegen/value/object.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::codegen::{
     api_model::{AsBackref, Ref, Reference, UnknownReference},
     make_ident, ApiModel, PropertyOverride,
@@ -139,10 +141,10 @@ impl<R> Default for Object<R> {
 impl<R> Object<R> {
     pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
     where
-        R: AsBackref,
+        R: AsBackref + fmt::Debug,
     {
         self.members.values().any(|member| {
-            let Some(item) = model.resolve_as_backref(&member.definition) else {
+            let Ok(item) = model.resolve(&member.definition) else {
                 return false;
             };
             item.value.use_display_from_str(model)

--- a/src/codegen/value/object.rs
+++ b/src/codegen/value/object.rs
@@ -76,15 +76,15 @@ impl ObjectMember {
 
         let serde_as = item
             .and_then(|item| item.use_display_from_str(model))
-            .map(|dfs| {
-                let dfs = if self.inline_option {
-                    quote!(Option<#dfs>)
+            .map(|annotation| {
+                let annotation = if self.inline_option {
+                    quote!(Option<#annotation>)
                 } else {
-                    dfs
+                    annotation
                 };
 
-                let dfs = dfs.to_string();
-                quote!(#[serde_as(as = #dfs)])
+                let annotation = annotation.to_string().replace(' ', "");
+                quote!(#[serde_as(as = #annotation)])
             });
 
         let mut serde_attributes = Vec::new();

--- a/src/codegen/value/one_of_enum.rs
+++ b/src/codegen/value/one_of_enum.rs
@@ -131,7 +131,7 @@ impl<R> OneOfEnum<R> {
             let Ok(item) = model.resolve(&variant.definition) else {
                 return false;
             };
-            item.value.use_display_from_str(model)
+            item.use_display_from_str(model).is_some()
         })
     }
 }

--- a/src/codegen/value/one_of_enum.rs
+++ b/src/codegen/value/one_of_enum.rs
@@ -2,7 +2,7 @@ use std::cell::OnceCell;
 
 use crate::{
     codegen::{
-        api_model::{Ref, Reference, UnknownReference},
+        api_model::{AsBackref, Ref, Reference, UnknownReference},
         make_ident,
     },
     ApiModel,
@@ -123,10 +123,15 @@ impl<R> Default for OneOfEnum<R> {
 }
 
 impl<R> OneOfEnum<R> {
-    pub fn use_serde_as_annotation(&self, model: &ApiModel) -> bool {
+    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
+    where
+        R: AsBackref,
+    {
         self.variants.iter().any(|variant| {
-            let Some(item) = model.resolve(variant.definition) else {return false};
-            item.value.use_serde_as_annotation(model)
+            let Some(item) = model.resolve_as_backref(&variant.definition) else {
+                return false;
+            };
+            item.value.use_display_from_str(model)
         })
     }
 }

--- a/src/codegen/value/one_of_enum.rs
+++ b/src/codegen/value/one_of_enum.rs
@@ -122,6 +122,15 @@ impl<R> Default for OneOfEnum<R> {
     }
 }
 
+impl<R> OneOfEnum<R> {
+    pub fn use_serde_as_annotation(&self, model: &ApiModel) -> bool {
+        self.variants.iter().any(|variant| {
+            let Some(item) = model.resolve(variant.definition) else {return false};
+            item.value.use_serde_as_annotation(model)
+        })
+    }
+}
+
 impl OneOfEnum<Ref> {
     pub(crate) fn new(
         spec: &OpenAPI,

--- a/src/codegen/value/one_of_enum.rs
+++ b/src/codegen/value/one_of_enum.rs
@@ -1,4 +1,4 @@
-use std::cell::OnceCell;
+use std::{cell::OnceCell, fmt};
 
 use crate::{
     codegen::{
@@ -125,10 +125,10 @@ impl<R> Default for OneOfEnum<R> {
 impl<R> OneOfEnum<R> {
     pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
     where
-        R: AsBackref,
+        R: AsBackref + fmt::Debug,
     {
         self.variants.iter().any(|variant| {
-            let Some(item) = model.resolve_as_backref(&variant.definition) else {
+            let Ok(item) = model.resolve(&variant.definition) else {
                 return false;
             };
             item.value.use_display_from_str(model)

--- a/src/codegen/value/scalar.rs
+++ b/src/codegen/value/scalar.rs
@@ -144,9 +144,11 @@ impl Scalar {
     ///
     /// Most primitives implement `serde::Serialize` and `serde::Deserialize`. However, that is not universally true:
     /// some require this helper for serialization. For that, they just need to implement `Display` and `FromStr`.
-    pub fn use_display_from_str(self) -> bool {
+    pub fn use_display_from_str(self) -> Option<TokenStream> {
         match self {
-            Scalar::Mime | Scalar::AcceptHeader => true,
+            Scalar::Mime | Scalar::AcceptHeader => {
+                Some(quote!(openapi_gen::reexport::serde_with::DisplayFromStr))
+            }
             Scalar::Unit
             | Scalar::F64
             | Scalar::F32
@@ -162,21 +164,21 @@ impl Scalar {
             | Scalar::Ipv4Addr
             | Scalar::Ipv6Addr
             | Scalar::Bool
-            | Scalar::Any => false,
+            | Scalar::Any => None,
             #[cfg(feature = "bytes")]
-            Scalar::Bytes => false,
+            Scalar::Bytes => None,
             #[cfg(feature = "uuid")]
-            Scalar::Uuid => false,
+            Scalar::Uuid => None,
             #[cfg(feature = "integer-restrictions")]
-            Scalar::BoundedI32(_, _) => false,
+            Scalar::BoundedI32(_, _) => None,
             #[cfg(feature = "integer-restrictions")]
-            Scalar::BoundedI64(_, _) => false,
+            Scalar::BoundedI64(_, _) => None,
             #[cfg(feature = "integer-restrictions")]
-            Scalar::BoundedU32(_, _) => false,
+            Scalar::BoundedU32(_, _) => None,
             #[cfg(feature = "integer-restrictions")]
-            Scalar::BoundedU64(_, _) => false,
+            Scalar::BoundedU64(_, _) => None,
             #[cfg(feature = "api-problem")]
-            Scalar::ApiProblem => false,
+            Scalar::ApiProblem => None,
         }
     }
 

--- a/src/codegen/value/scalar.rs
+++ b/src/codegen/value/scalar.rs
@@ -140,6 +140,46 @@ impl Scalar {
         }
     }
 
+    /// Should we use `serde_as::DisplayFromStr` for serialization for this type?
+    ///
+    /// Most primitives implement `serde::Serialize` and `serde::Deserialize`. However, that is not universally true:
+    /// some require this helper for serialization. For that, they just need to implement `Display` and `FromStr`.
+    pub fn use_display_from_str(self) -> bool {
+        match self {
+            Scalar::Mime | Scalar::AcceptHeader => true,
+            Scalar::Unit
+            | Scalar::F64
+            | Scalar::F32
+            | Scalar::I64
+            | Scalar::I32
+            | Scalar::U64
+            | Scalar::U32
+            | Scalar::String
+            | Scalar::Binary
+            | Scalar::Date
+            | Scalar::DateTime
+            | Scalar::IpAddr
+            | Scalar::Ipv4Addr
+            | Scalar::Ipv6Addr
+            | Scalar::Bool
+            | Scalar::Any => false,
+            #[cfg(feature = "bytes")]
+            Scalar::Bytes => false,
+            #[cfg(feature = "uuid")]
+            Scalar::Uuid => false,
+            #[cfg(feature = "integer-restrictions")]
+            Scalar::BoundedI32(_, _) => false,
+            #[cfg(feature = "integer-restrictions")]
+            Scalar::BoundedI64(_, _) => false,
+            #[cfg(feature = "integer-restrictions")]
+            Scalar::BoundedU32(_, _) => false,
+            #[cfg(feature = "integer-restrictions")]
+            Scalar::BoundedU64(_, _) => false,
+            #[cfg(feature = "api-problem")]
+            Scalar::ApiProblem => false,
+        }
+    }
+
     pub fn emit_type(self) -> TokenStream {
         match self {
             Scalar::Unit => quote!(()),

--- a/src/codegen/value/set.rs
+++ b/src/codegen/value/set.rs
@@ -13,15 +13,21 @@ pub struct Set<Ref = Reference> {
     pub item: Ref,
 }
 
-impl<R> Set<R> {
-    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
-    where
-        R: AsBackref + fmt::Debug,
-    {
+impl<R> Set<R>
+where
+    R: AsBackref + fmt::Debug,
+{
+    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool {
         let Ok(item) = model.resolve(&self.item) else {
             return false;
         };
-        item.value.use_display_from_str(model)
+        item.use_display_from_str(model).is_some()
+    }
+
+    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream> {
+        let item = model.resolve(&self.item).ok()?;
+        let inner = item.use_display_from_str(model)?;
+        Some(quote!(std::collections::HashSet<#inner>))
     }
 }
 

--- a/src/codegen/value/set.rs
+++ b/src/codegen/value/set.rs
@@ -1,6 +1,9 @@
-use crate::codegen::{
-    api_model::{Ref, Reference, UnknownReference},
-    make_ident,
+use crate::{
+    codegen::{
+        api_model::{AsBackref, Ref, Reference, UnknownReference},
+        make_ident,
+    },
+    ApiModel,
 };
 
 use proc_macro2::TokenStream;
@@ -9,6 +12,18 @@ use quote::quote;
 #[derive(Debug, Clone)]
 pub struct Set<Ref = Reference> {
     pub item: Ref,
+}
+
+impl<R> Set<R> {
+    pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
+    where
+        R: AsBackref,
+    {
+        let Some(item) = model.resolve_as_backref(&self.item) else {
+            return false;
+        };
+        item.value.use_display_from_str(model)
+    }
 }
 
 impl Set<Ref> {

--- a/src/codegen/value/set.rs
+++ b/src/codegen/value/set.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{
     codegen::api_model::{AsBackref, Ref, Reference, UnknownReference},
     ApiModel,
@@ -14,9 +16,9 @@ pub struct Set<Ref = Reference> {
 impl<R> Set<R> {
     pub(crate) fn use_serde_as_annotation(&self, model: &ApiModel<R>) -> bool
     where
-        R: AsBackref,
+        R: AsBackref + fmt::Debug,
     {
-        let Some(item) = model.resolve_as_backref(&self.item) else {
+        let Ok(item) = model.resolve(&self.item) else {
             return false;
         };
         item.value.use_display_from_str(model)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod reexport {
     pub use serde;
     pub use serde_enum_str;
     pub use serde_json;
+    pub use serde_with;
     pub use time;
     #[cfg(feature = "uuid")]
     pub use uuid;

--- a/tests/cases/fancy_types/definition.yaml
+++ b/tests/cases/fancy_types/definition.yaml
@@ -122,6 +122,20 @@ components:
         string_uuid:
           type: string
           format: uuid
+        string_mime:
+          type: string
+          format: mime
+        nullable_string_mime:
+          type: string
+          format: mime
+          nullable: true
+        optional_string_mime:
+          type: string
+          format: mime
+        optional_nullable_string_mime:
+          type: string
+          format: mime
+          nullable: true
         string_unrecognized:
           type: string
           format: unrecognized
@@ -157,4 +171,6 @@ components:
         - string_ipv4
         - string_ipv6
         - string_uuid
+        - string_mime
+        - nullable_string_mime
         - string_unrecognized

--- a/tests/cases/fancy_types/expect.rs
+++ b/tests/cases/fancy_types/expect.rs
@@ -1,4 +1,7 @@
 #![allow(non_camel_case_types)]
+#[openapi_gen::reexport::serde_with::serde_as(
+    crate = "openapi_gen::reexport::serde_with"
+)]
 #[derive(
     Debug,
     Clone,
@@ -76,6 +79,16 @@ pub struct Container {
     pub string_ipv4: std::net::Ipv4Addr,
     pub string_ipv6: std::net::Ipv6Addr,
     pub string_uuid: openapi_gen::reexport::uuid::Uuid,
+    #[serde_as(as = "openapi_gen::reexport::serde_with::DisplayFromStr")]
+    pub string_mime: openapi_gen::reexport::mime::Mime,
+    #[serde_as(as = "Option<openapi_gen::reexport::serde_with::DisplayFromStr>")]
+    pub nullable_string_mime: Option<openapi_gen::reexport::mime::Mime>,
+    #[serde_as(as = "Option<openapi_gen::reexport::serde_with::DisplayFromStr>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optional_string_mime: Option<openapi_gen::reexport::mime::Mime>,
+    #[serde_as(as = "Option<Option<openapi_gen::reexport::serde_with::DisplayFromStr>>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optional_nullable_string_mime: Option<Option<openapi_gen::reexport::mime::Mime>>,
     pub string_unrecognized: String,
 }
 #[openapi_gen::reexport::async_trait::async_trait]


### PR DESCRIPTION
Certain of our scalar types--notably `Mime`--do not implement `Serialize` or `Deserialize`. Obviously we want to use them anyway in arbitrary objects.

The `serde_with` crate provides a workaround: the `#[serde_as]` attribute macro. This PR enables that behavior.