### PR TITLE
explicitly emit serialization formats for time and date types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,12 @@ reqwest = { version = "0.11.18", features = ["blocking"] }
 serde = { version = "1.0.163", features = ["derive"] }
 serde-enum-str = "0.4.0"
 serde_json = "1.0.96"
-serde_with = { version = "3.2.0", features = ["macros"] }
+serde_with = { version = "3.2.0", features = ["macros", "time_0_3"] }
 serde_yaml = { version = "0.9.21", optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
 syn = "2.0.15"
 thiserror = "1.0.47"
-time = { version = "0.3.21", features = ["formatting", "parsing", "macros", "serde", "serde-human-readable"] }
+time = { version = "0.3.21", features = ["formatting", "parsing", "macros", "serde"] }
 uuid = { version = "1.3.2", features = ["fast-rng", "serde", "v4"], optional = true }
 
 [dev-dependencies]

--- a/src/codegen/item.rs
+++ b/src/codegen/item.rs
@@ -168,8 +168,8 @@ impl<R> Item<R>
 where
     R: AsBackref + fmt::Debug,
 {
-    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream> {
-        let mut vd = self.value.use_display_from_str(model)?;
+    pub(crate) fn serde_as_item_annotation(&self, model: &ApiModel<R>) -> Option<TokenStream> {
+        let mut vd = self.value.serde_as_item_annotation(model)?;
         if self.nullable {
             vd = quote!(Option<#vd>);
         }

--- a/src/codegen/value/list.rs
+++ b/src/codegen/value/list.rs
@@ -21,12 +21,12 @@ where
         let Ok(item) = model.resolve(&self.item) else {
             return false;
         };
-        item.use_display_from_str(model).is_some()
+        item.serde_as_item_annotation(model).is_some()
     }
 
-    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream> {
+    pub(crate) fn serde_as_item_annotation(&self, model: &ApiModel<R>) -> Option<TokenStream> {
         let item = model.resolve(&self.item).ok()?;
-        let inner = item.use_display_from_str(model)?;
+        let inner = item.serde_as_item_annotation(model)?;
         Some(quote!(Vec<#inner>))
     }
 }

--- a/src/codegen/value/map.rs
+++ b/src/codegen/value/map.rs
@@ -28,14 +28,14 @@ where
                 let Ok(item) = model.resolve(value_type_ref) else {
                     return false;
                 };
-                item.use_display_from_str(model).is_some()
+                item.serde_as_item_annotation(model).is_some()
             })
             .unwrap_or_default()
     }
 
-    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream> {
+    pub(crate) fn serde_as_item_annotation(&self, model: &ApiModel<R>) -> Option<TokenStream> {
         let item = model.resolve(self.value_type.as_ref()?).ok()?;
-        let inner = item.use_display_from_str(model)?;
+        let inner = item.serde_as_item_annotation(model)?;
         Some(quote!(std::collections::HashMap<String, #inner>))
     }
 }

--- a/src/codegen/value/mod.rs
+++ b/src/codegen/value/mod.rs
@@ -328,28 +328,28 @@ impl<R> Value<R> {
                 let Ok(item) = model.resolve(ref_) else {
                     return false;
                 };
-                item.use_display_from_str(model).is_some()
+                item.serde_as_item_annotation(model).is_some()
             }
         }
     }
 
-    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream>
+    pub(crate) fn serde_as_item_annotation(&self, model: &ApiModel<R>) -> Option<TokenStream>
     where
         R: AsBackref + fmt::Debug,
     {
         match self {
             // scalars might require this annotation natively
-            Value::Scalar(scalar) => scalar.use_display_from_str(),
+            Value::Scalar(scalar) => scalar.serde_as_item_annotation(),
             // types which contain multiple inner value types, or just strings,
             // can impl `DisplayFromStr` in their own interior
             Value::StringEnum(_) | Value::OneOfEnum(_) | Value::Object(_) => None,
             // types with a single receiver can recursively produce a `DisplayFromStr` requirement
-            Value::List(list) => list.use_display_from_str(model),
-            Value::Map(map) => map.use_display_from_str(model),
-            Value::Set(set_) => set_.use_display_from_str(model),
+            Value::List(list) => list.serde_as_item_annotation(model),
+            Value::Map(map) => map.serde_as_item_annotation(model),
+            Value::Set(set_) => set_.serde_as_item_annotation(model),
             Value::Ref(ref_) | Value::PropertyOverride(PropertyOverride { ref_, .. }) => {
                 let item = model.resolve(ref_).ok()?;
-                item.use_display_from_str(model)
+                item.serde_as_item_annotation(model)
             }
         }
     }

--- a/src/codegen/value/object.rs
+++ b/src/codegen/value/object.rs
@@ -75,7 +75,7 @@ impl ObjectMember {
         let write_only = self.write_only || get_property_override(&|prop| prop.write_only);
 
         let serde_as = item
-            .and_then(|item| item.use_display_from_str(model))
+            .and_then(|item| item.serde_as_item_annotation(model))
             .map(|annotation| {
                 let annotation = if self.inline_option {
                     quote!(Option<#annotation>)
@@ -161,7 +161,7 @@ impl<R> Object<R> {
             let Ok(item) = model.resolve(&member.definition) else {
                 return false;
             };
-            item.use_display_from_str(model).is_some()
+            item.serde_as_item_annotation(model).is_some()
         })
     }
 }

--- a/src/codegen/value/one_of_enum.rs
+++ b/src/codegen/value/one_of_enum.rs
@@ -131,7 +131,7 @@ impl<R> OneOfEnum<R> {
             let Ok(item) = model.resolve(&variant.definition) else {
                 return false;
             };
-            item.use_display_from_str(model).is_some()
+            item.serde_as_item_annotation(model).is_some()
         })
     }
 }

--- a/src/codegen/value/set.rs
+++ b/src/codegen/value/set.rs
@@ -21,12 +21,12 @@ where
         let Ok(item) = model.resolve(&self.item) else {
             return false;
         };
-        item.use_display_from_str(model).is_some()
+        item.serde_as_item_annotation(model).is_some()
     }
 
-    pub(crate) fn use_display_from_str(&self, model: &ApiModel<R>) -> Option<TokenStream> {
+    pub(crate) fn serde_as_item_annotation(&self, model: &ApiModel<R>) -> Option<TokenStream> {
         let item = model.resolve(&self.item).ok()?;
-        let inner = item.use_display_from_str(model)?;
+        let inner = item.serde_as_item_annotation(model)?;
         Some(quote!(std::collections::HashSet<#inner>))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod well_known_types;
 pub use as_status_code::AsStatusCode;
 
 pub mod fix_block_comments;
+pub mod serialization_helpers;
 
 pub use canonical_form::{
     CanonicalForm, CanonicalizeError, ConstraintViolation, Reason, ValidationError,

--- a/src/serialization_helpers/date_as_string.rs
+++ b/src/serialization_helpers/date_as_string.rs
@@ -1,0 +1,68 @@
+//! This module contains serialization helpers for [`time::Date`].
+//!
+//! There are two modes of use:
+//!
+//! - For raw dates, use serde's `with` attribute:
+//!
+//!     ```rust,ignore
+//!     #[derive(serde::Serialize)]
+//!     struct Foo {
+//!         #[serde(with = "date_as_string")]
+//!         date: Date,
+//!     }
+//!     ```
+//!
+//! - For composite date types, use `serde_with::serde_as`:
+//!
+//!     ```rust,ignore
+//!     #[serde_as]
+//!     #[derive(serde::Serialize)]
+//!     struct Foo {
+//!         #[serde_as(as = "Option<date_as_string::Ymd>")]
+//!         date: Option<Date>,
+//!     }
+//!     ```
+
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::{DeserializeAs, SerializeAs};
+use time::{format_description::FormatItem, macros::format_description, Date};
+
+pub const YMD_FORMAT: &[FormatItem<'_>] = format_description!(version = 2, "[year]-[month]-[day]");
+
+fn serialize<S>(date: &Date, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let s = date
+        .format(&YMD_FORMAT)
+        .expect("all dates can format into YMD");
+    s.serialize(serializer)
+}
+
+fn deserialize<'de, D>(deserializer: D) -> Result<Date, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    Date::parse(&s, &YMD_FORMAT).map_err(D::Error::custom)
+}
+
+pub struct Ymd;
+
+impl SerializeAs<Date> for Ymd {
+    fn serialize_as<S>(date: &Date, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize(date, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, Date> for Ymd {
+    fn deserialize_as<D>(deserializer: D) -> Result<Date, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize(deserializer)
+    }
+}

--- a/src/serialization_helpers/mod.rs
+++ b/src/serialization_helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod date_as_string;

--- a/tests/cases/fancy_types/expect.rs
+++ b/tests/cases/fancy_types/expect.rs
@@ -73,7 +73,11 @@ pub struct Container {
     pub string_binary: Vec<u8>,
     pub string_byte: openapi_gen::Bytes,
     pub string_base64: openapi_gen::Bytes,
+    #[serde_as(as = "openapi_gen::serialization_helpers::date_as_string::Ymd")]
     pub string_date: openapi_gen::reexport::time::Date,
+    #[serde_as(
+        as = "openapi_gen::reexport::time::format_description::well_known::Rfc3339"
+    )]
     pub string_datetime: openapi_gen::reexport::time::OffsetDateTime,
     pub string_ip: std::net::IpAddr,
     pub string_ipv4: std::net::Ipv4Addr,


### PR DESCRIPTION
This doesn't give a lot of flexibility, but makes things simple, consistent, and parseable across languages.

Date types are explicitly instructed to always be formatted as `YYYY-MM-DD`.

Datetime types are explicitly instructed to always be formatted per RFC 3339.