### PR TITLE
api problem rejection as default response 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab90e7b70bea63a153137162affb6a0bce26b584c24a4c7885509783e2cf30b"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1029,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-extra",
  "base64 0.21.0",
  "bounded-integer",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ accept-header = { version = "0.1.0", git = "https://github.com/coriolinus/accept
 anyhow = { version = "1.0.71" }
 async-trait = "0.1.68"
 axum = { version = "0.6.20", optional = true, features = ["headers"] }
+axum-extra = { version = "0.8.0", optional = true }
 base64 = { version = "0.21.0", optional = true }
 bounded-integer = { version = "0.5.6", features = ["std", "types", "serde1", "num-traits02"], optional = true }
 clap = { version = "4.2.7", features = ["derive"], optional = true }
@@ -49,7 +50,7 @@ vergen = { version = "8.2.4", features = ["git", "gitcl"] }
 
 [features]
 default = []
-api-problem = ["http-api-problem"]
+api-problem = ["axum-extra", "http-api-problem"]
 axum-support = ["axum", "headers"]
 cli = ["clap", "serde_yaml"]
 bytes = ["base64"]

--- a/src/axum_compat/api_problem_rejection.rs
+++ b/src/axum_compat/api_problem_rejection.rs
@@ -1,0 +1,41 @@
+use axum::{extract::rejection::JsonRejection, response::IntoResponse};
+use http::StatusCode;
+use http_api_problem::HttpApiProblem;
+
+#[derive(Debug)]
+pub struct ApiProblemRejection(pub HttpApiProblem);
+
+impl From<JsonRejection> for ApiProblemRejection {
+    fn from(value: JsonRejection) -> Self {
+        let status = match value {
+            JsonRejection::JsonDataError(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            JsonRejection::JsonSyntaxError(_) => StatusCode::BAD_REQUEST,
+            JsonRejection::MissingJsonContentType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            _ => StatusCode::BAD_REQUEST,
+        };
+        let title = value.to_string();
+
+        let mut err = &value as &dyn std::error::Error;
+        let mut detail = String::new();
+        while let Some(predecessor) = err.source() {
+            detail.extend(format!("{predecessor}; ").chars());
+            err = predecessor;
+        }
+
+        Self(HttpApiProblem::new(status).title(title).detail(detail))
+    }
+}
+
+impl IntoResponse for ApiProblemRejection {
+    fn into_response(self) -> axum::response::Response {
+        // we always set the status, but just in case...
+        let status = self.0.status.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+        (
+            status,
+            [(http::header::CONTENT_TYPE, "application/problem+json")],
+            axum::Json(self.0),
+        )
+            .into_response()
+    }
+}

--- a/src/axum_compat/mod.rs
+++ b/src/axum_compat/mod.rs
@@ -21,6 +21,11 @@ mod build_router;
 mod header;
 mod into_response;
 
+#[cfg(feature = "api-problem")]
+mod api_problem_rejection;
+#[cfg(feature = "api-problem")]
+pub use api_problem_rejection::ApiProblemRejection;
+
 pub use into_response::default_response;
 
 pub(crate) fn axum_items<'a>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub mod reexport {
     pub use async_trait;
     #[cfg(feature = "axum-support")]
     pub use axum;
+    #[cfg(all(feature = "axum-support", feature = "api-problem"))]
+    pub use axum_extra;
     #[cfg(feature = "integer-restrictions")]
     pub use bounded_integer;
     pub use derive_more;

--- a/tests/cases/18_response_value/expect.rs
+++ b/tests/cases/18_response_value/expect.rs
@@ -180,10 +180,14 @@ where
             openapi_gen::reexport::axum::routing::post({
                 let instance = instance.clone();
                 move |
-                    openapi_gen::reexport::axum::extract::Json(
-                        request_body,
-                    ): openapi_gen::reexport::axum::extract::Json<
-                        CreateNaturalPersonIdentificationRequest,
+                    openapi_gen::reexport::axum_extra::extract::WithRejection(
+                        openapi_gen::reexport::axum::extract::Json(request_body),
+                        _,
+                    ): openapi_gen::reexport::axum_extra::extract::WithRejection<
+                        openapi_gen::reexport::axum::extract::Json<
+                            CreateNaturalPersonIdentificationRequest,
+                        >,
+                        openapi_gen::axum_compat::ApiProblemRejection,
                     >|
                 async move {
                     instance.create_natural_person_identification(request_body).await

--- a/tests/cases/24_headers/expect.rs
+++ b/tests/cases/24_headers/expect.rs
@@ -309,10 +309,14 @@ where
                     x_request_id: Option<
                         openapi_gen::reexport::axum::extract::TypedHeader<XRequestId>,
                     >,
-                    openapi_gen::reexport::axum::extract::Json(
-                        request_body,
-                    ): openapi_gen::reexport::axum::extract::Json<
-                        CreateNaturalPersonIdentificationRequest,
+                    openapi_gen::reexport::axum_extra::extract::WithRejection(
+                        openapi_gen::reexport::axum::extract::Json(request_body),
+                        _,
+                    ): openapi_gen::reexport::axum_extra::extract::WithRejection<
+                        openapi_gen::reexport::axum::extract::Json<
+                            CreateNaturalPersonIdentificationRequest,
+                        >,
+                        openapi_gen::axum_compat::ApiProblemRejection,
                     >|
                 async move {
                     let x_flow_id = x_flow_id.map(|x_flow_id| x_flow_id.0);

--- a/tests/cases/item_ref/expect.rs
+++ b/tests/cases/item_ref/expect.rs
@@ -155,9 +155,13 @@ where
                     ): openapi_gen::reexport::axum::extract::Path<
                         PutThingPathParameters,
                     >,
-                    openapi_gen::reexport::axum::extract::Json(
-                        request_body,
-                    ): openapi_gen::reexport::axum::extract::Json<PutThingRequest>|
+                    openapi_gen::reexport::axum_extra::extract::WithRejection(
+                        openapi_gen::reexport::axum::extract::Json(request_body),
+                        _,
+                    ): openapi_gen::reexport::axum_extra::extract::WithRejection<
+                        openapi_gen::reexport::axum::extract::Json<PutThingRequest>,
+                        openapi_gen::axum_compat::ApiProblemRejection,
+                    >|
                 async move { instance.put_thing(id, request_body).await }
             }),
         )

--- a/tests/cases/request_enum/expect.rs
+++ b/tests/cases/request_enum/expect.rs
@@ -123,9 +123,13 @@ where
             openapi_gen::reexport::axum::routing::post({
                 let instance = instance.clone();
                 move |
-                    openapi_gen::reexport::axum::extract::Json(
-                        request_body,
-                    ): openapi_gen::reexport::axum::extract::Json<MultiRequestsRequest>|
+                    openapi_gen::reexport::axum_extra::extract::WithRejection(
+                        openapi_gen::reexport::axum::extract::Json(request_body),
+                        _,
+                    ): openapi_gen::reexport::axum_extra::extract::WithRejection<
+                        openapi_gen::reexport::axum::extract::Json<MultiRequestsRequest>,
+                        openapi_gen::axum_compat::ApiProblemRejection,
+                    >|
                 async move { instance.multi_requests(request_body).await }
             }),
         )
@@ -134,10 +138,14 @@ where
             openapi_gen::reexport::axum::routing::post({
                 let instance = instance.clone();
                 move |
-                    openapi_gen::reexport::axum::extract::Json(
-                        request_body,
-                    ): openapi_gen::reexport::axum::extract::Json<
-                        OptionalRequestBodyRequest,
+                    openapi_gen::reexport::axum_extra::extract::WithRejection(
+                        openapi_gen::reexport::axum::extract::Json(request_body),
+                        _,
+                    ): openapi_gen::reexport::axum_extra::extract::WithRejection<
+                        openapi_gen::reexport::axum::extract::Json<
+                            OptionalRequestBodyRequest,
+                        >,
+                        openapi_gen::axum_compat::ApiProblemRejection,
                     >|
                 async move { instance.optional_request_body(request_body).await }
             }),
@@ -147,9 +155,13 @@ where
             openapi_gen::reexport::axum::routing::post({
                 let instance = instance.clone();
                 move |
-                    openapi_gen::reexport::axum::extract::Json(
-                        request_body,
-                    ): openapi_gen::reexport::axum::extract::Json<SameRequestRequest>|
+                    openapi_gen::reexport::axum_extra::extract::WithRejection(
+                        openapi_gen::reexport::axum::extract::Json(request_body),
+                        _,
+                    ): openapi_gen::reexport::axum_extra::extract::WithRejection<
+                        openapi_gen::reexport::axum::extract::Json<SameRequestRequest>,
+                        openapi_gen::axum_compat::ApiProblemRejection,
+                    >|
                 async move { instance.same_request(request_body).await }
             }),
         )

--- a/tests/cases/trait_api/expect.rs
+++ b/tests/cases/trait_api/expect.rs
@@ -49,9 +49,13 @@ where
             openapi_gen::reexport::axum::routing::post({
                 let instance = instance.clone();
                 move |
-                    openapi_gen::reexport::axum::extract::Json(
-                        request_body,
-                    ): openapi_gen::reexport::axum::extract::Json<PostKudosRequest>|
+                    openapi_gen::reexport::axum_extra::extract::WithRejection(
+                        openapi_gen::reexport::axum::extract::Json(request_body),
+                        _,
+                    ): openapi_gen::reexport::axum_extra::extract::WithRejection<
+                        openapi_gen::reexport::axum::extract::Json<PostKudosRequest>,
+                        openapi_gen::axum_compat::ApiProblemRejection,
+                    >|
                 async move { instance.post_kudos(request_body).await }
             }),
         )

--- a/tests/cases/well_known_type/expect.rs
+++ b/tests/cases/well_known_type/expect.rs
@@ -49,10 +49,14 @@ where
             openapi_gen::reexport::axum::routing::post({
                 let instance = instance.clone();
                 move |
-                    openapi_gen::reexport::axum::extract::Json(
-                        request_body,
-                    ): openapi_gen::reexport::axum::extract::Json<
-                        PostWellKnownTypesRequest,
+                    openapi_gen::reexport::axum_extra::extract::WithRejection(
+                        openapi_gen::reexport::axum::extract::Json(request_body),
+                        _,
+                    ): openapi_gen::reexport::axum_extra::extract::WithRejection<
+                        openapi_gen::reexport::axum::extract::Json<
+                            PostWellKnownTypesRequest,
+                        >,
+                        openapi_gen::axum_compat::ApiProblemRejection,
                     >|
                 async move { instance.post_well_known_types(request_body).await }
             }),


### PR DESCRIPTION
If the generator is built with both the `axum-compat` and `api-problem` features selected, emit a wrapper type in the router builder such that JSON deserialization failures get emitted as `HttpApiProblem` instances, with appropriate `application/problem+json` `content-type`.

This is probably desired behavior in all cases where both those features are selected, but it is definitely desired behavior in idv2, where the absence of this behavior is causing proptest failures.